### PR TITLE
feat: BadgeEvent v1 + signed /session/start route

### DIFF
--- a/src/app/api/session/start/route.ts
+++ b/src/app/api/session/start/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Session Start API Route
+ * 
+ * POST /api/session/start
+ * 
+ * Validates BadgeEvent v1 payload from iOS kiosk app and returns session token.
+ * 
+ * Security:
+ * - HMAC-SHA256 request signature verification
+ * - Timestamp validation (5-min window)
+ * - Replay attack prevention (nonce)
+ * - Schema validation
+ */
+
+// Force Node.js runtime to access Node crypto module
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { validateAndAuthorizeSessionStart, generateRandomHex } from '@/lib/backend/validation';
+
+/**
+ * Simple in-memory rate limiter
+ */
+const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
+const RATE_LIMIT = 30; // requests per window
+const RATE_WINDOW_MS = 60 * 1000; // 1 minute
+
+function checkRateLimit(identifier: string): boolean {
+  const now = Date.now();
+  const record = rateLimitMap.get(identifier);
+  
+  if (!record || now > record.resetTime) {
+    rateLimitMap.set(identifier, { count: 1, resetTime: now + RATE_WINDOW_MS });
+    return true;
+  }
+  
+  if (record.count >= RATE_LIMIT) {
+    return false;
+  }
+  
+  record.count++;
+  return true;
+}
+
+/**
+ * POST /api/session/start
+ */
+export async function POST(request: Request) {
+  try {
+    // Rate limiting
+    const clientIp = request.headers.get('x-forwarded-for') ?? 'unknown';
+    if (!checkRateLimit(clientIp)) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded' },
+        { status: 429 }
+      );
+    }
+    
+    // Get full URL for signature verification
+    const url = new URL(request.url);
+    const fullUrl = `${url.protocol}//${url.host}${url.pathname}`;
+    
+    // Parse body
+    const body = await request.json();
+    
+    // Get security headers
+    const headers: Record<string, string | undefined> = {
+      'x-signature': request.headers.get('x-signature') ?? undefined,
+      'x-timestamp': request.headers.get('x-timestamp') ?? undefined,
+      'x-nonce': request.headers.get('x-nonce') ?? undefined,
+    };
+    
+    // Validate request
+    const validation = await validateAndAuthorizeSessionStart(
+      headers,
+      body,
+      fullUrl,
+      'POST'
+    );
+    
+    if (!validation.valid) {
+      console.error('[SessionStart] Validation failed:', validation.error);
+      return NextResponse.json(
+        { error: validation.error },
+        { status: 401 }
+      );
+    }
+    
+    const event = validation.event!;
+    
+    // Log badge scan event
+    console.log('[SessionStart] Badge scan event:', {
+      eventId: event.eventId,
+      badgeId: event.badge.badgeId,
+      readerType: event.reader.readerType,
+      timestamp: event.timestamp,
+    });
+    
+    // TODO: Validate badge against backend database
+    // TODO: Check enrollment status
+    // TODO: Generate session token
+    
+    // For now, return a mock response for development
+    const sessionToken = generateRandomHex(32);
+    const expiresAt = new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString(); // 8 hours
+    
+    return NextResponse.json({
+      success: true,
+      sessionToken,
+      persona: {
+        roleId: 'role-001',
+        roleName: 'Standard User',
+        permissions: ['read', 'write'],
+        workspaceConfig: {
+          layout: 'grid',
+          visibleModules: ['dashboard', 'apps', 'settings'],
+          theme: {
+            primaryColor: '#007bff',
+            accentColor: '#6610f2',
+          },
+        },
+        appLaunchConfig: {
+          apps: [
+            { bundleId: 'com.example.app1', name: 'App 1' },
+            { bundleId: 'com.example.app2', name: 'App 2' },
+          ],
+        },
+      },
+      expiresAt,
+    });
+  } catch (error) {
+    console.error('[SessionStart] Error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/backend/validation.ts
+++ b/src/lib/backend/validation.ts
@@ -1,0 +1,238 @@
+/**
+ * Backend validation module for BadgeEvent v1
+ * 
+ * Provides:
+ * - HMAC-SHA256 request signature verification
+ * - Replay attack prevention (nonce store)
+ * - Schema validation using Zod
+ */
+
+import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto';
+import { z } from 'zod';
+
+/**
+ * Configuration for request signing
+ */
+const SIGNING_CONFIG = {
+  /** Secret key for HMAC-SHA256 - in production, use environment variable */
+  secretKey: process.env.BACKEND_SIGNING_SECRET ?? 'development-secret-key',
+  /** Time window for request validity (5 minutes in ms) */
+  validityWindowMs: 5 * 60 * 1000,
+  /** Nonce storage TTL (10 minutes in ms) */
+  nonceTtlMs: 10 * 60 * 1000,
+};
+
+// In-memory nonce store (use Redis in production)
+const nonceStore = new Map<string, number>();
+
+/**
+ * BadgeEvent v1 schema validation
+ */
+const BadgeDataSchema = z.object({
+  badgeId: z.string().min(1),
+  employeeId: z.string().optional(),
+  cardSerialNumber: z.string().optional(),
+});
+
+const ReaderDataSchema = z.object({
+  readerId: z.string().min(1),
+  readerType: z.enum(['ble', 'usb', 'nfc']),
+  readerName: z.string().optional(),
+});
+
+const DeviceDataSchema = z.object({
+  deviceId: z.string().min(1),
+  deviceSerial: z.string().min(1),
+  deviceModel: z.string().min(1),
+  osVersion: z.string().min(1),
+});
+
+const MDMDataSchema = z.object({
+  enrolled: z.boolean(),
+  managementId: z.string().optional(),
+  personaAttributes: z.record(z.string(), z.string()).optional(),
+});
+
+const EventContextSchema = z.object({
+  locationId: z.string().optional(),
+  locationName: z.string().optional(),
+  applicationId: z.string().optional(),
+});
+
+export const BadgeEventSchema = z.object({
+  schemaVersion: z.literal('1.0'),
+  eventType: z.literal('badge.scan'),
+  eventId: z.string().uuid(),
+  timestamp: z.string().datetime(),
+  badge: BadgeDataSchema,
+  reader: ReaderDataSchema,
+  device: DeviceDataSchema,
+  mdm: MDMDataSchema,
+  context: EventContextSchema.optional(),
+});
+
+export type BadgeEvent = z.infer<typeof BadgeEventSchema>;
+
+/**
+ * Generate a random hex string
+ */
+export function generateRandomHex(byteLength: number): string {
+  return randomBytes(byteLength).toString('hex');
+}
+
+/**
+ * Generate a signature base string for HMAC
+ * Format: METHOD|FFULL_URL|TIMESTAMP|NONCE|BODY_STRING
+ */
+function generateSignatureBase(
+  method: string,
+  fullUrl: string,
+  timestamp: number,
+  nonce: string,
+  bodyString: string
+): string {
+  return `${method}|${fullUrl}|${timestamp}|${nonce}|${bodyString}`;
+}
+
+/**
+ * Create HMAC-SHA256 signature
+ */
+function createSignature(data: string, key: string): string {
+  return createHmac('sha256', key).update(data).digest('hex');
+}
+
+/**
+ * Verify HMAC-SHA256 signature using constant-time comparison
+ */
+function verifySignature(data: string, key: string, signature: string): boolean {
+  const expectedSignature = createSignature(data, key);
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+  const signatureBuffer = Buffer.from(signature, 'hex');
+  
+  // Constant-time comparison to prevent timing attacks
+  return timingSafeEqual(expectedBuffer, signatureBuffer);
+}
+
+/**
+ * Check if nonce exists and is still valid
+ */
+function isNonceValid(nonce: string): boolean {
+  const existingTs = nonceStore.get(nonce);
+  if (existingTs) {
+    return false; // Nonce already used
+  }
+  
+  // Store nonce with current timestamp
+  nonceStore.set(nonce, Date.now());
+  
+  // Clean up old nonces
+  const now = Date.now();
+  for (const [key, ts] of nonceStore.entries()) {
+    if (now - ts > SIGNING_CONFIG.nonceTtlMs) {
+      nonceStore.delete(key);
+    }
+  }
+  
+  return true;
+}
+
+/**
+ * Validation result
+ */
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+  event?: BadgeEvent;
+}
+
+/**
+ * Validate and authorize a session start request
+ * 
+ * @param headers - Request headers containing signature, timestamp, nonce
+ * @param body - Request body (parsed BadgeEvent)
+ * @param fullUrl - Full URL of the request
+ * @param method - HTTP method
+ */
+export async function validateAndAuthorizeSessionStart(
+  headers: {
+    'x-signature'?: string;
+    'x-timestamp'?: string;
+    'x-nonce'?: string;
+  },
+  body: unknown,
+  fullUrl: string,
+  method: string
+): Promise<ValidationResult> {
+  const { 'x-signature': signature, 'x-timestamp': timestamp, 'x-nonce': nonce } = headers;
+  
+  // 1. Check required headers
+  if (!signature || !timestamp || !nonce) {
+    return {
+      valid: false,
+      error: 'Missing required security headers: x-signature, x-timestamp, x-nonce',
+    };
+  }
+  
+  // 2. Validate timestamp is within window
+  const requestTime = parseInt(timestamp, 10);
+  if (isNaN(requestTime)) {
+    return { valid: false, error: 'Invalid timestamp format' };
+  }
+  
+  const now = Date.now();
+  const timeDiff = Math.abs(now - requestTime);
+  if (timeDiff > SIGNING_CONFIG.validityWindowMs) {
+    return { valid: false, error: 'Request timestamp outside valid window' };
+  }
+  
+  // 3. Check replay prevention (nonce)
+  if (!isNonceValid(nonce)) {
+    return { valid: false, error: 'Nonce already used or invalid' };
+  }
+  
+  // 4. Validate schema
+  const parseResult = BadgeEventSchema.safeParse(body);
+  if (!parseResult.success) {
+    return {
+      valid: false,
+      error: `Invalid BadgeEvent schema: ${parseResult.error.message}`,
+    };
+  }
+  
+  const event = parseResult.data;
+  
+  // 5. Verify signature
+  const bodyString = JSON.stringify(body);
+  const signatureBase = generateSignatureBase(
+    method,
+    fullUrl,
+    requestTime,
+    nonce,
+    bodyString
+  );
+  
+  if (!verifySignature(signatureBase, SIGNING_CONFIG.secretKey, signature)) {
+    return { valid: false, error: 'Invalid signature' };
+  }
+  
+  // All validations passed
+  return {
+    valid: true,
+    event,
+  };
+}
+
+/**
+ * Generate expected signature for iOS to include
+ * (For testing/documentation purposes)
+ */
+export function generateExpectedSignature(
+  method: string,
+  fullUrl: string,
+  timestamp: number,
+  nonce: string,
+  bodyString: string
+): string {
+  const base = generateSignatureBase(method, fullUrl, timestamp, nonce, bodyString);
+  return createSignature(base, SIGNING_CONFIG.secretKey);
+}

--- a/src/lib/types/badge-event.ts
+++ b/src/lib/types/badge-event.ts
@@ -1,0 +1,93 @@
+/**
+ * BadgeEvent v1 frozen schema types
+ * 
+ * Schema Version: 1.0
+ * Status: FROZEN - Do not modify field names or types
+ * 
+ * This schema defines the event structure for badge scan events
+ * sent from iOS kiosk app to the backend.
+ */
+
+export interface BadgeData {
+  readonly badgeId: string;
+  readonly employeeId?: string;
+  readonly cardSerialNumber?: string;
+}
+
+export interface ReaderData {
+  readonly readerId: string;
+  readonly readerType: 'ble' | 'usb' | 'nfc';
+  readonly readerName?: string;
+}
+
+export interface DeviceData {
+  readonly deviceId: string;
+  readonly deviceSerial: string;
+  readonly deviceModel: string;
+  readonly osVersion: string;
+}
+
+export interface MDMData {
+  readonly enrolled: boolean;
+  readonly managementId?: string;
+  readonly personaAttributes?: Record<string, string>;
+}
+
+export interface EventContext {
+  readonly locationId?: string;
+  readonly locationName?: string;
+  readonly applicationId?: string;
+}
+
+/**
+ * BadgeEvent v1 - frozen schema
+ * Used for badge scan authentication events
+ */
+export interface BadgeEvent {
+  readonly schemaVersion: '1.0';
+  readonly eventType: 'badge.scan';
+  readonly eventId: string;        // UUIDv4
+  readonly timestamp: string;       // ISO-8601
+  readonly badge: BadgeData;
+  readonly reader: ReaderData;
+  readonly device: DeviceData;
+  readonly mdm: MDMData;
+  readonly context?: EventContext;
+}
+
+/**
+ * Backend response types
+ */
+export interface BackendPersona {
+  readonly roleId: string;
+  readonly roleName: string;
+  readonly permissions: string[];
+  readonly workspaceConfig: {
+    readonly layout: string;
+    readonly visibleModules: string[];
+    readonly theme: {
+      readonly primaryColor: string;
+      readonly accentColor: string;
+    };
+  };
+  readonly appLaunchConfig: {
+    readonly apps: Array<{
+      readonly bundleId: string;
+      readonly name: string;
+    }>;
+  };
+}
+
+export interface SessionStartResponse {
+  readonly success: boolean;
+  readonly sessionToken?: string;
+  readonly persona?: BackendPersona;
+  readonly expiresAt?: string;
+  readonly error?: string;
+}
+
+export interface BackendErrorResponse {
+  readonly error: string;
+  readonly code?: string;
+  readonly message?: string;
+}


### PR DESCRIPTION
•	Adds frozen BadgeEvent v1 types (src/lib/types/badge-event.ts)
	•	Adds backend validation and HMAC-SHA256 verification with replay prevention (src/lib/backend/validation.ts)
	•	Adds Next.js API route /api/session/start with Node runtime (src/app/api/session/start/route.ts)
	•	Commit: 939222d