### PR TITLE
MVP: closed-loop /api/session/start decision flow, posture service, and demo contract

### DIFF
--- a/docs/MVP_DEMO_CONTRACT.md
+++ b/docs/MVP_DEMO_CONTRACT.md
@@ -1,0 +1,167 @@
+# SignalGrid MVP Demo Contract (Closed-Loop Session Start)
+
+This document defines the **MVP-only** contract for `/api/session/start`.
+
+## Scope
+
+This contract is intentionally constrained to the session-start closed loop:
+
+1. Receive signed badge-scan session-start input.
+2. Resolve badge identity.
+3. Evaluate posture + remediation outcome.
+4. Return **allow/deny** decision receipt.
+5. Write audit output for every decision path.
+
+No additional policy/orchestration scope is included here.
+
+---
+
+## Supported Inputs
+
+### Endpoint
+
+- `POST /api/session/start`
+
+### Headers
+
+Required security headers:
+
+- `x-signature`
+- `x-timestamp`
+- `x-nonce`
+
+Optional:
+
+- `x-request-id`
+
+### Body (BadgeEvent v1 + MVP posture hints)
+
+Required BadgeEvent shape:
+
+- `schemaVersion` = `"1.0"`
+- `eventType` = `"badge.scan"`
+- `eventId` (uuid)
+- `timestamp` (ISO-8601)
+- `badge.badgeId`
+- `reader.readerId`, `reader.readerType`
+- `device.deviceId`, `device.deviceSerial`, `device.deviceModel`, `device.osVersion`
+- `mdm.enrolled`
+
+MVP posture/remediation hints use `mdm.personaAttributes`:
+
+- `complianceStatus`: `compliant | non_compliant | unknown`
+- `remediationAttempted`: `"true" | "false"`
+- `remediationSucceeded`: `"true" | "false"`
+
+---
+
+## Decision Behavior
+
+The MVP closed-loop decisions are deterministic:
+
+1. **Compliant → allow**
+   - `complianceStatus = compliant`
+   - session is created
+   - decision = `allow`
+
+2. **Non-compliant → remediation attempt → final allow or deny**
+   - `complianceStatus = non_compliant`
+   - remediation is considered attempted via `remediationAttempted`
+   - if `remediationSucceeded = true`, final decision is `allow`
+   - otherwise final decision is `deny`
+
+3. **Unknown → fail-closed deny**
+   - `complianceStatus = unknown` (or missing/unrecognized)
+   - final decision is `deny`
+   - no open-by-default path exists for unknown posture in MVP
+
+---
+
+## Response Contract
+
+Every response returns a decision receipt with these top-level fields:
+
+- `decision`: `allow | deny`
+- `reason`: human-readable reason for demo clarity
+- `timestamp`: ISO-8601 decision time
+- `remediation`: object **only when remediation was attempted**
+
+### Allow response
+
+```json
+{
+  "success": true,
+  "decision": "allow",
+  "reason": "Device posture is compliant",
+  "timestamp": "2026-04-05T00:00:00.000Z",
+  "session": {
+    "sessionId": "session-...",
+    "userId": "...",
+    "deviceId": "...",
+    "nextAction": "LAUNCH_APP",
+    "bundleId": "com.signalgrid.demo",
+    "createdAt": "...",
+    "expiresAt": "..."
+  }
+}
+```
+
+### Deny response
+
+```json
+{
+  "success": false,
+  "decision": "deny",
+  "reason": "Posture unknown; fail-closed deny",
+  "timestamp": "2026-04-05T00:00:00.000Z"
+}
+```
+
+### Remediation object
+
+When remediation is attempted, include:
+
+```json
+"remediation": {
+  "attempted": true,
+  "status": "succeeded | failed",
+  "reason": "..."
+}
+```
+
+---
+
+## Audit Contract
+
+For **every decision path**, the endpoint writes audit entries:
+
+1. `session.start`
+2. `decision.allow` or `decision.deny`
+
+Audit metadata includes:
+
+- `decision`
+- `reason`
+- `timestamp`
+- `badgeId`
+- `remediation` (when attempted)
+
+This applies to:
+
+- successful allow
+- deny due to non-compliance after remediation attempt
+- deny due to unknown posture (fail-closed)
+- deny due to validation/rate-limit/internal error
+
+---
+
+## Explicit MVP Non-Goals
+
+The following are intentionally out of scope for this MVP contract:
+
+1. Full policy DSL / multi-step rule evaluation expansion.
+2. New decision outcomes beyond `allow` and `deny`.
+3. Advanced remediation workflows (ticketing, device command fan-out, retries).
+4. Cross-endpoint orchestration redesign.
+5. Broad schema evolution beyond the existing BadgeEvent + personaAttributes hints.
+

--- a/src/app/api/session/start/route.ts
+++ b/src/app/api/session/start/route.ts
@@ -1,3 +1,323 @@
-// Route for Session Start
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAndAuthorizeSessionStart } from '@/lib/backend/validation';
+import { badgeRegistry } from '@/lib/badgeRegistry';
+import { getSessionStoreFromRequest } from '@/lib/tenant/sessionStore';
+import { appendAuditRecord } from '@/lib/auditLedger';
+import { checkDeviceRateLimit, checkIpRateLimit } from './services/rateLimit';
+import { evaluatePostureDecision, RemediationAttempt } from './services/posture';
 
-(Your content here)
+export const runtime = 'nodejs';
+
+type SessionStartDecision = 'allow' | 'deny';
+
+interface DecisionMeta {
+  decision: SessionStartDecision;
+  reason: string;
+  timestamp: string;
+  remediation?: RemediationAttempt;
+}
+
+function buildDecisionResponse(params: {
+  success: boolean;
+  status: number;
+  decision: SessionStartDecision;
+  reason: string;
+  session?: {
+    sessionId: string;
+    userId: string;
+    deviceId: string;
+    nextAction?: string;
+    bundleId?: string;
+    createdAt: string;
+    expiresAt: string;
+  };
+  remediation?: RemediationAttempt;
+}) {
+  const timestamp = new Date().toISOString();
+
+  return NextResponse.json(
+    {
+      success: params.success,
+      decision: params.decision,
+      reason: params.reason,
+      timestamp,
+      remediation: params.remediation,
+      session: params.session,
+    },
+    { status: params.status }
+  );
+}
+
+async function writeSessionStartAudit(params: {
+  eventType: 'decision.allow' | 'decision.deny';
+  actorId: string;
+  deviceId: string;
+  badgeId: string;
+  requestId?: string;
+  meta: DecisionMeta;
+}) {
+  await appendAuditRecord('session.start', { type: 'device', id: params.actorId }, {
+    requestId: params.requestId,
+    target: { type: 'session', id: params.deviceId },
+    meta: {
+      badgeId: params.badgeId,
+      ...params.meta,
+    },
+  });
+
+  await appendAuditRecord(params.eventType, { type: 'device', id: params.actorId }, {
+    requestId: params.requestId,
+    target: { type: 'device', id: params.deviceId },
+    meta: {
+      badgeId: params.badgeId,
+      ...params.meta,
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const timestamp = new Date().toISOString();
+  const requestId = request.headers.get('x-request-id') ?? undefined;
+
+  try {
+    const rawBody = (await request.json()) as unknown;
+
+    const validation = await validateAndAuthorizeSessionStart(
+      {
+        'x-signature': request.headers.get('x-signature') ?? undefined,
+        'x-timestamp': request.headers.get('x-timestamp') ?? undefined,
+        'x-nonce': request.headers.get('x-nonce') ?? undefined,
+      },
+      rawBody,
+      request.url,
+      request.method
+    );
+
+    if (!validation.valid || !validation.event) {
+      const reason = validation.error ?? 'Session start validation failed';
+      await appendAuditRecord('session.start', { type: 'device', id: 'unknown' }, {
+        requestId,
+        target: { type: 'session', id: 'unknown' },
+        meta: {
+          decision: 'deny',
+          reason,
+          code: validation.code,
+          timestamp,
+        },
+      });
+
+      await appendAuditRecord('decision.deny', { type: 'device', id: 'unknown' }, {
+        requestId,
+        target: { type: 'device', id: 'unknown' },
+        meta: {
+          decision: 'deny',
+          reason,
+          code: validation.code,
+          timestamp,
+        },
+      });
+
+      return NextResponse.json(
+        {
+          success: false,
+          decision: 'deny',
+          reason,
+          timestamp,
+        },
+        { status: 401 }
+      );
+    }
+
+    const event = validation.event;
+    const deviceId = event.device.deviceId;
+    const badgeId = event.badge.badgeId;
+    const actorId = event.reader.readerId || deviceId;
+
+    const clientIp =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? request.headers.get('x-real-ip')
+      ?? 'unknown';
+
+    if (!checkIpRateLimit(clientIp) || !checkDeviceRateLimit(deviceId)) {
+      const reason = 'Rate limit exceeded for session start';
+      await writeSessionStartAudit({
+        eventType: 'decision.deny',
+        actorId,
+        deviceId,
+        badgeId,
+        requestId,
+        meta: {
+          decision: 'deny',
+          reason,
+          timestamp,
+        },
+      });
+
+      return buildDecisionResponse({
+        success: false,
+        status: 429,
+        decision: 'deny',
+        reason,
+      });
+    }
+
+    const badgeMapping = await badgeRegistry.get(badgeId);
+    if (!badgeMapping || !badgeMapping.active) {
+      const reason = 'Badge is not enrolled or inactive';
+      await writeSessionStartAudit({
+        eventType: 'decision.deny',
+        actorId,
+        deviceId,
+        badgeId,
+        requestId,
+        meta: {
+          decision: 'deny',
+          reason,
+          timestamp,
+        },
+      });
+
+      return buildDecisionResponse({
+        success: false,
+        status: 403,
+        decision: 'deny',
+        reason,
+      });
+    }
+
+    const posture = evaluatePostureDecision(event);
+
+    if (posture.finalStatus === 'unknown') {
+      const reason = 'Posture unknown; fail-closed deny';
+      await writeSessionStartAudit({
+        eventType: 'decision.deny',
+        actorId,
+        deviceId,
+        badgeId,
+        requestId,
+        meta: {
+          decision: 'deny',
+          reason,
+          timestamp,
+          remediation: posture.remediation,
+        },
+      });
+
+      return buildDecisionResponse({
+        success: false,
+        status: 403,
+        decision: 'deny',
+        reason,
+        remediation: posture.remediation,
+      });
+    }
+
+    if (posture.finalStatus === 'non_compliant') {
+      const reason = posture.remediation?.attempted
+        ? 'Remediation attempted but device remains non-compliant'
+        : 'Device is non-compliant';
+
+      await writeSessionStartAudit({
+        eventType: 'decision.deny',
+        actorId,
+        deviceId,
+        badgeId,
+        requestId,
+        meta: {
+          decision: 'deny',
+          reason,
+          timestamp,
+          remediation: posture.remediation,
+        },
+      });
+
+      return buildDecisionResponse({
+        success: false,
+        status: 403,
+        decision: 'deny',
+        reason,
+        remediation: posture.remediation,
+      });
+    }
+
+    const sessionStore = getSessionStoreFromRequest(request);
+    const session = await sessionStore.create({
+      userId: badgeMapping.userId,
+      badgeUid: badgeId,
+      deviceId,
+      nextAction: 'LAUNCH_APP',
+      bundleId: 'com.signalgrid.demo',
+      metadata: {
+        badgeReaderId: event.reader.readerId,
+        postureInitialStatus: posture.initialStatus,
+        postureFinalStatus: posture.finalStatus,
+        remediation: posture.remediation,
+      },
+    });
+
+    await badgeRegistry.updateLastUsed(badgeId);
+
+    const reason = posture.remediation?.attempted
+      ? 'Remediation succeeded; access allowed'
+      : 'Device posture is compliant';
+
+    await writeSessionStartAudit({
+      eventType: 'decision.allow',
+      actorId,
+      deviceId,
+      badgeId,
+      requestId,
+      meta: {
+        decision: 'allow',
+        reason,
+        timestamp,
+        remediation: posture.remediation,
+      },
+    });
+
+    return buildDecisionResponse({
+      success: true,
+      status: 200,
+      decision: 'allow',
+      reason,
+      remediation: posture.remediation,
+      session: {
+        sessionId: session.sessionId,
+        userId: session.userId,
+        deviceId: session.deviceId,
+        nextAction: session.nextAction,
+        bundleId: session.bundleId,
+        createdAt: session.createdAt,
+        expiresAt: session.expiresAt,
+      },
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'Session start failed unexpectedly';
+    await appendAuditRecord('session.start', { type: 'system', id: 'session-start-api' }, {
+      requestId,
+      target: { type: 'session', id: 'unknown' },
+      meta: {
+        decision: 'deny',
+        reason,
+        timestamp,
+      },
+    });
+
+    await appendAuditRecord('decision.deny', { type: 'system', id: 'session-start-api' }, {
+      requestId,
+      target: { type: 'device', id: 'unknown' },
+      meta: {
+        decision: 'deny',
+        reason,
+        timestamp,
+      },
+    });
+
+    return buildDecisionResponse({
+      success: false,
+      status: 500,
+      decision: 'deny',
+      reason: 'Internal error during session start',
+    });
+  }
+}

--- a/src/app/api/session/start/route.ts
+++ b/src/app/api/session/start/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateAndAuthorizeSessionStart } from '@/lib/backend/validation';
 import { badgeRegistry } from '@/lib/badgeRegistry';
 import { getSessionStoreFromRequest } from '@/lib/tenant/sessionStore';
+import { resolveTenantId } from '@/lib/tenant/tenantContext';
 import { appendAuditRecord } from '@/lib/auditLedger';
 import { checkDeviceRateLimit, checkIpRateLimit } from './services/rateLimit';
 import { evaluatePostureDecision, RemediationAttempt } from './services/posture';
@@ -78,6 +79,7 @@ async function writeSessionStartAudit(params: {
 export async function POST(request: NextRequest) {
   const timestamp = new Date().toISOString();
   const requestId = request.headers.get('x-request-id') ?? undefined;
+  const tenantId = resolveTenantId(request);
 
   try {
     const rawBody = (await request.json()) as unknown;
@@ -90,7 +92,8 @@ export async function POST(request: NextRequest) {
       },
       rawBody,
       request.url,
-      request.method
+      request.method,
+      tenantId
     );
 
     if (!validation.valid || !validation.event) {

--- a/src/app/api/session/start/services/posture.ts
+++ b/src/app/api/session/start/services/posture.ts
@@ -1,3 +1,85 @@
-// Service for Start Session Posture
+import { BadgeEvent } from '@/lib/backend/validation';
 
-(Your content here)
+export type PostureStatus = 'compliant' | 'non_compliant' | 'unknown';
+
+export type RemediationStatus = 'succeeded' | 'failed';
+
+export interface RemediationAttempt {
+  attempted: true;
+  status: RemediationStatus;
+  reason: string;
+}
+
+export interface PostureDecision {
+  initialStatus: PostureStatus;
+  finalStatus: PostureStatus;
+  remediation?: RemediationAttempt;
+}
+
+function normalizePostureStatus(raw: string | undefined): PostureStatus {
+  if (!raw) return 'unknown';
+
+  const value = raw.trim().toLowerCase();
+  if (value === 'compliant') return 'compliant';
+  if (value === 'non_compliant' || value === 'non-compliant') return 'non_compliant';
+  return 'unknown';
+}
+
+function asBoolean(raw: string | undefined): boolean {
+  return raw?.trim().toLowerCase() === 'true';
+}
+
+/**
+ * MVP posture/resolution contract:
+ * - complianceStatus comes from mdm.personaAttributes.complianceStatus
+ * - non_compliant posture always attempts remediation when remediationAttempted=true
+ * - remediation outcome can set final status to compliant
+ */
+export function evaluatePostureDecision(event: BadgeEvent): PostureDecision {
+  const attrs = event.mdm.personaAttributes ?? {};
+  const initialStatus = normalizePostureStatus(attrs.complianceStatus);
+
+  if (initialStatus !== 'non_compliant') {
+    return {
+      initialStatus,
+      finalStatus: initialStatus,
+    };
+  }
+
+  const remediationRequested = asBoolean(attrs.remediationAttempted);
+  if (!remediationRequested) {
+    return {
+      initialStatus,
+      finalStatus: 'non_compliant',
+      remediation: {
+        attempted: true,
+        status: 'failed',
+        reason: 'Remediation required but not attempted',
+      },
+    };
+  }
+
+  const remediationSucceeded = asBoolean(attrs.remediationSucceeded);
+
+  if (remediationSucceeded) {
+    return {
+      initialStatus,
+      finalStatus: 'compliant',
+      remediation: {
+        attempted: true,
+        status: 'succeeded',
+        reason: 'Remediation completed and posture became compliant',
+      },
+    };
+  }
+
+  return {
+    initialStatus,
+    finalStatus: 'non_compliant',
+    remediation: {
+      attempted: true,
+      status: 'failed',
+      reason: 'Remediation attempted but posture remains non-compliant',
+    },
+  };
+}


### PR DESCRIPTION
### Motivation

- Complete the MVP closed-loop session-start flow to make deterministic allow/deny decisions for demo: compliant → allow, non-compliant → remediation attempt → final allow/deny, and unknown → fail-closed deny.
- Make demo outputs explicit and easy to understand by adding a small response contract and ensuring every decision path is auditable.

### Description

- Implemented the session-start HTTP handler at `POST /api/session/start` with signed request validation, rate limiting, badge enrollment checks, deterministic posture handling, session creation, and decision receipts containing `decision`, `reason`, `timestamp`, and `remediation` (when applicable). (file: `src/app/api/session/start/route.ts`).
- Added a posture evaluation service `evaluatePostureDecision` that normalizes `mdm.personaAttributes` and models remediation attempts and outcomes for the MVP contract. (file: `src/app/api/session/start/services/posture.ts`).
- Ensured every decision path writes audit records (`session.start` plus `decision.allow` or `decision.deny`) including validation failures, rate-limits, badge failures, posture denies/allows, and internal errors. (file: `src/app/api/session/start/route.ts`).
- Added `docs/MVP_DEMO_CONTRACT.md` documenting supported inputs, deterministic decision behavior, response contract, audit contract, and explicit MVP non-goals.

### Testing

- Ran `npx eslint` on the modified files (`src/app/api/session/start/route.ts`, `src/app/api/session/start/services/posture.ts`) and it completed without changes reported for these files.
- Ran `npm run typecheck` (full `tsc --noEmit`) and observed failures that are pre-existing and unrelated to this change in other files (`src/app/api/admin/integrations/uem/enrollment/route.ts`, `src/app/api/admin/integrations/uem/enrollment/schema.ts`, `src/app/demo/page.tsx`, `src/app/investor-deck/page.tsx`, `src/app/page.tsx`), and no new type issues were introduced by the session-start changes based on isolated checks.
- Commits include the three modified/added files: `src/app/api/session/start/route.ts`, `src/app/api/session/start/services/posture.ts`, and `docs/MVP_DEMO_CONTRACT.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ed737a64832eb0eeb20958d6711a)