### PR TITLE
Fix invalid exports in UEM enrollment Next.js route

### DIFF
--- a/src/app/api/admin/integrations/uem/enrollment/route.ts
+++ b/src/app/api/admin/integrations/uem/enrollment/route.ts
@@ -16,7 +16,7 @@ import { deviceRegistry } from '@/lib/deviceRegistry';
 /**
  * Normalized device enrollment data from any UEM
  */
-export const UEMEnrollmentSchema = z.object({
+const UEMEnrollmentSchema = z.object({
   // Device identification
   deviceId: z.string(), // UEM-specific device ID
   serialNumber: z.string().optional(),
@@ -53,8 +53,6 @@ export const UEMEnrollmentSchema = z.object({
   // Timestamp
   eventTimestamp: z.string().datetime(),
 });
-
-export type UEMEnrollment = z.infer<typeof UEMEnrollmentSchema>;
 
 // ============================================================================
 // POST Handler - Receive enrollment webhook


### PR DESCRIPTION
### Motivation
- A non-handler export in the UEM enrollment App Route caused Next.js to reject the route during type validation, blocking the build; the change removes that noise so the build can progress to the next real issue.

### Description
- In `src/app/api/admin/integrations/uem/enrollment/route.ts` the exported Zod schema and exported inferred type were made module-local (removed `export` and the `UEMEnrollment` type alias) to eliminate invalid route exports while preserving request validation and response behavior.

### Testing
- Ran `bun run build`, which confirmed the original Next.js route export/type error for the UEM enrollment route is resolved and the build now fails later on an unrelated type error in `src/app/api/session/start/route.ts` (`expiresAt` type mismatch), indicating this PR clears the targeted blocker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb29c4b78c832eb0edbd3ddb637d1c)