### PR TITLE
Reframe product messaging as a runtime decision layer; update website and docs

### DIFF
--- a/docs/ABOUT_SIGNALGRID.md
+++ b/docs/ABOUT_SIGNALGRID.md
@@ -1,27 +1,39 @@
 # About SignalGrid
 
 ## Short company description
-SignalGrid is building a closed-loop decision layer for session-start access risk. We help security and IT teams decide, remediate when needed, and return a final auditable access outcome before workflows break.
+SignalGrid is the runtime decision layer between authentication and enforcement that resolves identity, device, and session risk before access breaks.
+
+## Medium company description
+Modern enterprise stacks can authenticate identity, enforce policy, and visualize issues, but they still leave a critical gap between risk detection and final access outcome. SignalGrid fills that gap by evaluating identity, device posture, and session risk at runtime, attempting remediation when possible, re-evaluating trust, and returning a final access decision before disruption reaches the business.
 
 ## Longer company description
-SignalGrid focuses on the decision gap between risk detection and final access outcome. Many organizations already have strong tools for posture reporting and policy enforcement, but operators still get pulled into manual remediation when risk appears at login. SignalGrid adds a closed-loop step at session start: evaluate risk, attempt remediation for non-compliant posture, re-check trust, and return a final allow/deny result with audit context. The current product is intentionally MVP-scoped and designed for early design partners validating this closed-loop flow.
+SignalGrid exists to close the decision gap between authentication and enforcement in modern enterprise environments. Today’s stacks are strong at verifying identity, managing endpoints, and observing failures, but they still leave operators with the same problem: when runtime conditions degrade, the common result is a block, a lockout, or a manual recovery process. SignalGrid adds a runtime decision layer that connects identity, device, and session signals, attempts remediation when possible, re-evaluates trust, and returns the correct final access outcome before disruption reaches the business.
+
+SignalGrid's core principle: access decisions should reflect runtime truth, not stale or incomplete signals.
 
 ## One-line product description
-SignalGrid is a closed-loop decision layer that evaluates session-start risk, attempts remediation for non-compliant posture, and returns a final access decision with audit context.
+SignalGrid is a runtime decision layer that evaluates identity, device, and session risk at session start, attempts remediation when possible, and returns a final access decision with audit context.
 
 ## Problem statement
-Security teams can detect posture risk and enforce allow/deny policy, but often lack an operational loop that handles remediation attempts and clear final outcomes at session start. This creates manual work, slower access decisions, and inconsistent decision trails.
+Authentication and enforcement are necessary, but they are not sufficient. When risk is detected, most systems either block access or rely on manual intervention. That creates lockouts, delays, and operational friction at exactly the moment when systems should be making the right decision automatically.
 
 ## Solution statement
-SignalGrid runs in the pre-access decision path. It ingests identity/device/session risk inputs, applies policy logic, attempts remediation for non-compliant posture, re-evaluates trust, and returns a final decision (`allow` or `deny`) with explainable reasons and an auditable record.
+SignalGrid sits between authentication and enforcement to make the correct access decision at runtime. It evaluates identity, device posture, and session risk, attempts remediation when possible, re-evaluates trust after response, and returns a final allow or deny outcome with audit context.
+
+## Differentiator
+Authentication proves identity. SignalGrid ensures the system is actually capable of operating before access is granted.
+
+## Guardrail
+SignalGrid does not replace IAM, UEM, or DEX tools. It operationalizes real-time decisioning between them.
 
 ## Where SignalGrid fits (vs. Intune/Entra and existing security tooling)
 - **Intune (or other UEM/MDM):** source of device and compliance posture signals.
 - **Entra Conditional Access (or similar enforcement layer):** enforces access controls based on policy outcomes.
-- **SignalGrid:** decision-and-closure layer between detection and outcome at session start.
+- **DEX tools:** highlight user experience and endpoint failures.
+- **SignalGrid:** runtime decision layer between authentication and enforcement that determines what happens next.
 - **Other security tooling (SIEM/ITSM/NAC):** surrounding systems for monitoring and operations; not replaced by SignalGrid.
 
-In practice: Intune reports posture, Entra enforces policy, and SignalGrid closes the loop on what happens next when posture risk appears.
+In practice: UEM tools show what is configured, DEX tools show what is failing, enforcement systems apply policy outcomes, and SignalGrid decides what happens next. SignalGrid does not replace IAM, UEM, DEX, or enforcement tooling.
 
 ## MVP boundary statement
 SignalGrid is currently in MVP closed-loop launch mode, scoped to session-start behavior:

--- a/docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md
+++ b/docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md
@@ -8,9 +8,12 @@ Hi {{FirstName}},
 
 Thank you for reaching out and for your interest in SignalGrid.
 
-SignalGrid is a closed-loop decision layer focused on session-start access risk. Before access continues, SignalGrid evaluates identity, device, and session posture, attempts remediation when possible, and then returns a final auditable allow/deny outcome. We are currently in MVP closed-loop launch mode, with scope intentionally limited to this flow.
+SignalGrid is the runtime decision layer between authentication and enforcement. It evaluates identity, device, and session risk at runtime, attempts remediation when possible, re-evaluates trust, and returns a final access decision before workflows are disrupted. We are currently in MVP closed-loop launch mode, focused on a narrow session-start use case.
+Our core principle is simple: access decisions should reflect runtime truth, not stale or incomplete signals.
 
-If helpful, I’d be glad to schedule a short 20-minute design-partner/pilot conversation to learn about your environment and confirm fit.
+We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. We do not replace IAM, UEM, DEX, or enforcement systems.
+
+If helpful, I’d be glad to schedule a short 20-minute design-partner conversation and learn how your team handles runtime access failures today.
 
 To prepare, three quick questions:
 1. What typically happens today when a device or session fails policy checks at login/session start?

--- a/docs/FOUNDER_ONE_PAGER.md
+++ b/docs/FOUNDER_ONE_PAGER.md
@@ -4,24 +4,29 @@
 **SignalGrid**
 
 ## One-line product description
-SignalGrid is a closed-loop decision layer that evaluates session-start risk, attempts remediation for non-compliant posture, and returns a final access outcome with audit context.
+SignalGrid is the runtime decision layer between authentication and enforcement that evaluates identity, device, and session risk, attempts remediation when possible, and returns a final access outcome with audit context.
+
+## Founder / investor blurb
+Modern security stacks are fragmented across identity, device, experience, and enforcement layers. Those systems can authenticate, configure, and observe—but they still do not own the decision of what happens next when runtime conditions degrade. SignalGrid is the runtime decision layer that unifies those signals, attempts remediation when possible, and determines the correct access outcome before disruption occurs.
 
 ## Problem
 Security and access teams often have the right controls but a broken flow at decision time:
+- Identity systems authenticate.
 - Device and posture systems report state.
-- Conditional access systems enforce allow/deny.
+- Enforcement systems apply allow/deny policy.
 - When risk is found, users and operators still fall into manual, slow remediation paths.
 
-The gap is the loop between detection, remediation attempt, and final outcome before workflow disruption.
+The gap is the runtime loop between authentication, remediation attempt, and final outcome before workflow disruption.
 
 ## Solution
-SignalGrid runs in the decision path before access proceeds:
+SignalGrid runs in the runtime decision path between authentication and enforcement before access proceeds:
 1. Ingests identity/device/session risk inputs at session start.
 2. Evaluates trust and determines whether remediation should be attempted.
 3. Re-evaluates trust after remediation attempt.
 4. Returns a final `allow` or `deny` decision with reasons and audit trail.
 
 This positions SignalGrid as additive to existing controls, not a rip-and-replace replacement.
+SignalGrid ensures access decisions reflect runtime truth, not stale or incomplete signals.
 
 ## MVP scope (locked)
 Current MVP is intentionally narrow and focused on the session-start closed loop:
@@ -34,12 +39,13 @@ Current MVP is intentionally narrow and focused on the session-start closed loop
 Out of scope for MVP: full enterprise remediation integrations, complete production hardening, and broad multi-system orchestration.
 
 ## Where SignalGrid fits (Intune / Entra / broader tooling)
-SignalGrid sits above system-of-record and enforcement controls:
+SignalGrid sits between system-of-record and enforcement controls:
 - **Intune (or other UEM/MDM):** provides device/compliance posture signals.
+- **DEX platforms:** show endpoint/user experience failures and friction signals.
 - **Entra Conditional Access (or equivalent):** enforces access policy outcomes.
-- **SignalGrid:** decides what should happen next when risk is detected, including remediation attempt and final outcome logic.
+- **SignalGrid:** runtime decision layer that decides what should happen next when risk is detected, including remediation attempt and final outcome logic.
 
-In short: Intune reports posture, Entra enforces policy, and SignalGrid closes the operational loop between detection and outcome.
+In short: UEM tools show what is configured, DEX tools show what is failing, and SignalGrid decides what happens next before enforcement. SignalGrid is additive and does not replace IAM, UEM, DEX, or enforcement systems.
 
 ## Who it is for
 - Identity and access teams.

--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -11,15 +11,18 @@ Use it for:
 
 ## Core Narrative (60–90 seconds)
 
-Most IT and security teams are overwhelmed by repetitive identity and endpoint operations that still require human follow-up. Every manual review creates delay, inconsistency, and ticket backlog.
+Most IT and security teams are overloaded by access-risk operations that still require human follow-up. Every manual review creates delay, inconsistency, and ticket backlog.
 
-Our platform turns those high-friction workflows into policy-driven automations with explicit audit trails. Instead of adding another dashboard, we focus on reducing manual effort where teams already work (Intune, Entra, and adjacent systems) while preserving control and visibility.
+SignalGrid is the runtime decision layer between authentication and enforcement. At session start, we evaluate identity, device, and session risk, attempt remediation when possible, re-check trust, and return a final access decision with an audit trail before users hit disruption.
 
-The practical outcome is faster response on access and device-risk events, fewer policy exceptions, and measurable reduction in operational drag without forcing a complete process rewrite.
+We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. The practical outcome is faster decisions, less manual remediation work, and clearer accountability without rip-and-replace.
+Runtime truth matters: we have seen environments that still appear healthy while silently losing the ability to establish new TCP connections after prolonged uptime, forcing manual recovery and disruption.
+Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
+SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.
 
 ## Positioning Statement
 
-We help IT and security teams automate high-volume Intune/Entra workflows with clear policy controls, so they can ship consistent outcomes faster and with less manual toil.
+SignalGrid helps IT and security teams make runtime access decisions between authentication and enforcement by resolving identity, device, and session risk before access breaks.
 
 ## Ideal Customer Profile (ICP)
 
@@ -48,6 +51,7 @@ We help IT and security teams automate high-volume Intune/Entra workflows with c
 - “Where does human intervention happen most often?”
 - “How often do exceptions or retries happen?”
 - “How do you currently audit who approved what and why?”
+- “Where do authentication checks end and enforcement begin today?”
 
 ### 3) Risk and Constraints (4–6 min)
 - “What is the failure mode you’re most worried about?”
@@ -83,7 +87,7 @@ That can work for isolated tasks. The tradeoff is long-term maintainability, gov
 Agreed. Pilot scope should start with bounded workflows, explicit approvals where needed, and pre-agreed rollback paths. The objective is safe automation with evidence, not blind automation.
 
 ### “We already have too many tools.”
-Understood. The goal is not a new destination UI. We prioritize workflow outcomes, integration with existing systems, and minimizing additional operational surface area.
+Understood. SignalGrid is not a replacement for IAM, UEM, or DEX. The goal is a runtime decision layer that uses your existing tools and minimizes additional operational surface area.
 
 ## Pilot Offer Template
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,45 +4,59 @@ export default function HomePage() {
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
         <header className="space-y-5 border-b border-neutral-800 pb-10">
           <p className="text-sm font-medium uppercase tracking-[0.2em] text-neutral-400">SignalGrid</p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">Fix Risk Before It Breaks Access</h1>
+          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+            Fix Risk Before It Breaks Access
+          </h1>
           <p className="max-w-3xl text-lg text-neutral-300">
-            SignalGrid detects risk, makes the access decision, and closes the loop before users get stuck in manual
-            remediation.
+            SignalGrid is the runtime decision layer between authentication and enforcement that resolves identity,
+            device, and session risk before access breaks.
           </p>
         </header>
 
         <section className="space-y-8">
           <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
+            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Where SignalGrid fits</h2>
+            <p className="mt-3 text-neutral-200">
+              Identity systems authenticate. Access systems enforce. SignalGrid decides what happens in between.
+            </p>
+          </article>
+
+          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
             <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Why now</h2>
             <p className="mt-3 text-neutral-200">
-              Most access and security decisions still happen too late—after trust is assumed, after a session is
-              established, or after risk is already present.
+              Modern enterprise environments can verify identity, enforce policy, and visualize issues, but they still
+              leave a runtime decision gap. When risk is detected, most systems either block the user or rely on manual
+              remediation.
             </p>
           </article>
 
           <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">How it works</h2>
+            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Runtime truth</h2>
             <p className="mt-3 text-neutral-200">
-              SignalGrid evaluates identity, device posture, and session context before access proceeds. When risk is
-              detected, it can attempt remediation, re-evaluate trust, and return a final decision with auditability.
+              Even when authentication succeeds and compliance looks healthy, runtime conditions can still silently
+              fail. We have seen operating environments appear healthy while losing the ability to establish new TCP
+              connections after prolonged uptime, forcing manual recovery and disruption. SignalGrid helps ensure
+              access decisions reflect runtime truth, not stale or incomplete signals.
             </p>
           </article>
 
           <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Closed-loop value</h2>
+            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">What SignalGrid does</h2>
             <p className="mt-3 text-neutral-200">
-              Most systems stop at blocking. SignalGrid closes the loop by detecting risk, attempting remediation,
-              re-evaluating trust, and returning a final decision before the workflow breaks.
+              SignalGrid connects identity, device posture, and runtime risk signals, determines whether remediation
+              can be attempted, re-evaluates trust after response, and returns a final allow or deny decision with
+              audit context.
             </p>
           </article>
 
           <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Who it&apos;s for</h2>
+            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Differentiation</h2>
             <p className="mt-3 text-neutral-200">
-              Built for identity, endpoint, mobility, and Zero Trust teams that need clearer decisions before access
-              proceeds.
+              UEM tools show what&apos;s configured. DEX tools show what&apos;s failing. SignalGrid decides what happens
+              next and returns a final access decision before workflow disruption.
             </p>
           </article>
+
         </section>
 
         <section className="flex flex-col items-start gap-4 border-t border-neutral-800 pt-10">


### PR DESCRIPTION
### Motivation
- Align product positioning to emphasize SignalGrid as the runtime decision layer between authentication and enforcement rather than a generic "closed-loop" description.
- Make messaging consistent across website, sales materials, founder one-pager, and outreach templates to reduce confusion about scope and integration assumptions.
- Clarify that SignalGrid is additive (not a replacement for IAM/UEM/DEX) and highlight runtime truth and remediation intent.

### Description
- Updated `docs/ABOUT_SIGNALGRID.md` to reframe short/medium/long descriptions, add differentiator and guardrail sections, and clarify where SignalGrid fits versus UEM/DEX/enforcement tools.
- Edited `docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md` to refresh outreach copy, add the core principle line, and reiterate that SignalGrid is additive to existing controls.
- Revised `docs/FOUNDER_ONE_PAGER.md` to update problem/solution text, add founder blurb, and include DEX/UEM clarifications and phrasing about runtime truth.
- Updated `docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md` to refresh core narrative, positioning, objection handling, and discovery prompts to match new runtime-decision messaging.
- Modified frontend landing page `src/app/page.tsx` to replace hero and section copy with the new positioning, add a "Where SignalGrid fits" card, adjust headings, and refine wording in feature cards.

### Testing
- Ran a local production build with `npm run build` which completed successfully.
- Performed a TypeScript check with `npm run type-check` which passed without errors.
- Ran linters with `npm run lint` and automated style checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84a612978832ebff7aeb578a5c600)