### PR TITLE
Harden session start flow and fail-fast webhook retries

### DIFF
--- a/src/app/api/session/start/route.ts
+++ b/src/app/api/session/start/route.ts
@@ -1,90 +1,169 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { appendAuditRecord } from '@/lib/auditLedger';
-import { attemptRemediation, detectIssue, type SessionStartInput } from './services/posture';
-import { allow, deny } from './services/responses';
+import { appendAuditRecord, recordAuthFailure } from '@/lib/auditLedger';
+import { validateAndAuthorizeSessionStart } from '@/lib/backend/validation';
+import { getBadgeRegistry } from '@/lib/tenant/badgeRegistry';
+import { getSessionStore } from '@/lib/tenant/sessionStore';
+import { getEvaluator } from '@/lib/tenant/policyEvaluator';
+import { resolveTenantId } from '@/lib/tenant/tenantContext';
+import { emitAuthFailure, emitSessionStart } from '@/lib/integrations/webhooks/emitter';
+import { checkDeviceRateLimit, checkIpRateLimit } from './services/rateLimit';
+import { getFleetContext, getUEMContext } from './services/posture';
+import { buildDeniedPolicyInput, buildGrantedPolicyInput, recordDeniedPolicySideEffects } from './services/policy';
+import { createDeniedDeviceResponse } from './services/responses';
 
-function isPosture(value: unknown): value is SessionStartInput['posture'] {
-  return value === 'compliant' || value === 'non_compliant' || value === 'unknown';
-}
-
-function validateInput(payload: unknown): SessionStartInput | null {
-  if (!payload || typeof payload !== 'object') {
-    return null;
-  }
-
-  const value = payload as Record<string, unknown>;
-  const userId = value.userId;
-  const deviceId = value.deviceId;
-  const posture = value.posture;
-  const issue = value.issue;
-
-  if (typeof userId !== 'string' || typeof deviceId !== 'string' || !isPosture(posture)) {
-    return null;
-  }
-
+function toMode(nextAction?: string, bundleId?: string) {
   return {
-    userId,
-    deviceId,
-    posture,
-    issue: typeof issue === 'string' ? issue : undefined,
+    nextAction: nextAction || 'LAUNCH_APP',
+    bundleId: bundleId || 'com.example.enterpriseapp',
   };
 }
 
+function ttlSeconds(): number {
+  const value = Number.parseInt(process.env.SESSION_TTL_SECONDS ?? '28800', 10);
+  return Number.isFinite(value) && value > 0 ? value : 28800;
+}
+
 export async function POST(request: NextRequest) {
-  try {
-    const payload = await request.json();
-    const input = validateInput(payload);
+  const tenantId = resolveTenantId(request);
+  const badgeRegistry = getBadgeRegistry(tenantId);
+  const sessionStore = getSessionStore(tenantId);
+  const evaluator = getEvaluator(tenantId);
 
-    if (!input) {
-      return NextResponse.json(
-        {
-          error:
-            'Invalid payload. Expected: { userId: string, deviceId: string, posture: compliant|non_compliant|unknown, issue?: string }',
-        },
-        { status: 400 }
-      );
-    }
+  const body = await request.json().catch(() => null);
+  const headers = {
+    'x-signature': request.headers.get('x-signature') ?? undefined,
+    'x-timestamp': request.headers.get('x-timestamp') ?? undefined,
+    'x-nonce': request.headers.get('x-nonce') ?? undefined,
+  };
 
-    if (input.posture === 'compliant') {
-      await appendAuditRecord('decision.allow', { type: 'user', id: input.userId }, {
-        target: { type: 'device', id: input.deviceId },
-        meta: { reason: 'device compliant', posture: input.posture },
-      });
+  const validation = await validateAndAuthorizeSessionStart(headers, body, request.url, request.method, tenantId);
+  if (!validation.valid || !validation.event) {
+    await recordAuthFailure('validation_failed', { type: 'device' }, { meta: { code: validation.code } });
+    await emitAuthFailure({ deviceId: 'unknown', reason: validation.error || 'Validation failed', code: validation.code, timestamp: new Date().toISOString() });
+    const invalidSignature = validation.code === 'invalid_signature' || /invalid signature/i.test(validation.error ?? '');
+    const status = invalidSignature ? 401 : 400;
+    return NextResponse.json({ error: validation.error || 'Unauthorized' }, { status });
+  }
 
-      return allow('device compliant');
-    }
+  const event = validation.event;
+  const deviceId = event.device.deviceId;
+  const clientIp = request.headers.get('x-forwarded-for') ?? 'unknown';
 
-    if (input.posture === 'non_compliant') {
-      const issue = detectIssue(input);
-      const remediation = attemptRemediation(issue);
+  if (!checkIpRateLimit(clientIp) || !checkDeviceRateLimit(deviceId)) {
+    await recordAuthFailure('rate_limit_exceeded', { type: 'device', id: deviceId });
+    return NextResponse.json({ error: 'Rate limit exceeded', code: 'RATE_LIMIT' }, { status: 429 });
+  }
 
-      if (remediation.result === 'success') {
-        await appendAuditRecord('decision.allow', { type: 'user', id: input.userId }, {
-          target: { type: 'device', id: input.deviceId },
-          meta: { reason: 'device remediated', posture: input.posture, remediation },
-        });
+  const badgeMapping = await badgeRegistry.get(event.badge.badgeId);
+  if (!badgeMapping) {
+    return NextResponse.json({ error: 'Badge not enrolled', code: 'BADGE_NOT_ENROLLED' }, { status: 404 });
+  }
+  if (badgeMapping.active === false) {
+    return NextResponse.json({ error: 'Badge is deactivated', code: 'BADGE_INACTIVE' }, { status: 403 });
+  }
 
-        return allow('device remediated', remediation);
-      }
+  const existingSessions = await sessionStore.getByDeviceId(deviceId);
+  const existing = existingSessions.find((s) => s.status === 'active');
+  if (existing) {
+    const expiresAt = new Date(Date.now() + ttlSeconds() * 1000).toISOString();
+    await sessionStore.update(existing.sessionId, { expiresAt, lastActivityAt: new Date().toISOString() });
+    const updated = await sessionStore.get(existing.sessionId);
+    return NextResponse.json({
+      success: true,
+      message: 'Existing session extended',
+      session: {
+        sessionId: existing.sessionId,
+        expiresAt: updated?.expiresAt ?? expiresAt,
+        ...toMode(existing.nextAction, existing.bundleId),
+      },
+    });
+  }
 
-      await appendAuditRecord('decision.deny', { type: 'user', id: input.userId }, {
-        target: { type: 'device', id: input.deviceId },
-        meta: { reason: 'device non-compliant', posture: input.posture, remediation },
-      });
+  const fleetContext = await getFleetContext(event.device.deviceSerial);
+  const uemContext = await getUEMContext(event.device.deviceSerial);
 
-      return deny('device non-compliant', remediation);
-    }
+  const isUnknown = fleetContext.status === 'unknown' || uemContext.complianceStatus === 'unknown';
+  if (isUnknown && process.env.UNKNOWN_POSTURE_MODE !== 'allow') {
+    await recordAuthFailure('device_posture_unknown', { type: 'device', id: deviceId }, {
+      meta: { unknownPostureMode: 'deny' },
+    });
+    return NextResponse.json({ error: 'Device posture unknown', code: 'DEVICE_POSTURE_UNKNOWN' }, { status: 403 });
+  }
 
-    await appendAuditRecord('decision.deny', { type: 'user', id: input.userId }, {
-      target: { type: 'device', id: input.deviceId },
-      meta: { reason: 'unknown posture', posture: input.posture },
+  const isNonCompliant = fleetContext.status === 'non_compliant' || uemContext.complianceStatus === 'non_compliant';
+  if (isNonCompliant) {
+    const deniedInput = await buildDeniedPolicyInput({
+      event,
+      deviceId,
+      badgeMapping,
+      uemContext,
+      fleetContext,
+      isFleetCompliant: false,
+      isDeviceCompliant: false,
     });
 
-    return deny('unknown posture');
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Unknown error' },
-      { status: 500 }
-    );
+    const actions = await evaluator.evaluate(deniedInput.policyContext as any);
+    recordDeniedPolicySideEffects({
+      policyActions: actions as any,
+      deviceId,
+      userId: badgeMapping.userId,
+      badgeId: event.badge.badgeId,
+      userName: badgeMapping.userName,
+      riskScore: deniedInput.riskScore.riskScore,
+    });
+
+    return createDeniedDeviceResponse();
   }
+
+  const created = await sessionStore.create({
+    userId: badgeMapping.userId,
+    badgeUid: event.badge.badgeId,
+    deviceId,
+    nextAction: 'LAUNCH_APP',
+    bundleId: 'com.example.enterpriseapp',
+  });
+
+  const granted = await buildGrantedPolicyInput({
+    event,
+    deviceId,
+    badgeMapping,
+    uemContext,
+    fleetContext,
+    sessionId: created.sessionId,
+    sessionCreatedAt: created.createdAt,
+  });
+
+  const actions = await evaluator.evaluate(granted.policyContext as any);
+  const launchAction = actions.find((a: any) => a.type === 'launch_app');
+  const ttlAction = actions.find((a: any) => a.type === 'set_session_ttl');
+
+  const resolvedMode = toMode(
+    launchAction ? 'LAUNCH_APP' : created.nextAction,
+    launchAction?.params?.appBundleId || created.bundleId
+  );
+
+  if (ttlAction?.params?.seconds) {
+    const nextExpiry = new Date(Date.now() + Number(ttlAction.params.seconds) * 1000).toISOString();
+    await sessionStore.update(created.sessionId, { expiresAt: nextExpiry });
+  }
+
+  const hydratedSession = await sessionStore.get(created.sessionId);
+  const session = {
+    sessionId: created.sessionId,
+    expiresAt: hydratedSession?.expiresAt ?? created.expiresAt,
+    ...resolvedMode,
+  };
+
+  await badgeRegistry.updateLastUsed(event.badge.badgeId);
+  await appendAuditRecord('session.start', { type: 'user', id: badgeMapping.userId }, { target: { type: 'session', id: created.sessionId } });
+  await emitSessionStart({ sessionId: created.sessionId, userId: badgeMapping.userId, deviceId, badgeId: event.badge.badgeId, timestamp: new Date().toISOString() });
+
+  return NextResponse.json({
+    success: true,
+    decision: 'ACCESS_GRANTED',
+    session,
+    actions,
+    riskScore: granted.riskScore.riskScore,
+    riskLevel: granted.riskScore.riskLevel,
+  });
 }

--- a/src/app/api/session/start/services/posture.ts
+++ b/src/app/api/session/start/services/posture.ts
@@ -1,48 +1,20 @@
-export type Posture = 'compliant' | 'non_compliant' | 'unknown';
+export type PostureStatus = 'compliant' | 'non_compliant' | 'unknown';
 
-export type SessionStartInput = {
-  userId: string;
-  deviceId: string;
-  posture: Posture;
-  issue?: string;
+export type FleetContext = {
+  status: PostureStatus;
+  enrolled: boolean;
+  lastSeenAge?: number;
 };
 
-export type RemediationResult = {
-  attempted: boolean;
-  issue?: string;
-  action?: string;
-  result: 'success' | 'failed' | 'not_attempted';
+export type UEMContext = {
+  complianceStatus: PostureStatus;
+  enrolled: boolean;
 };
 
-export function detectIssue(input: SessionStartInput): string {
-  if (input.issue && input.issue.trim().length > 0) {
-    return input.issue;
-  }
-
-  return 'policy_violation';
+export async function getFleetContext(_deviceSerial?: string): Promise<FleetContext> {
+  return { status: 'unknown', enrolled: false };
 }
 
-export function attemptRemediation(issue: string): RemediationResult {
-  if (!issue) {
-    return {
-      attempted: false,
-      result: 'not_attempted',
-    };
-  }
-
-  if (issue === 'os_outdated') {
-    return {
-      attempted: true,
-      issue,
-      action: 'trigger_os_update',
-      result: 'success',
-    };
-  }
-
-  return {
-    attempted: true,
-    issue,
-    action: 'open_helpdesk_ticket',
-    result: 'failed',
-  };
+export async function getUEMContext(_deviceSerial?: string): Promise<UEMContext> {
+  return { complianceStatus: 'unknown', enrolled: false };
 }

--- a/src/app/api/session/start/services/responses.ts
+++ b/src/app/api/session/start/services/responses.ts
@@ -1,30 +1,8 @@
 import { NextResponse } from 'next/server';
-import type { RemediationResult } from './posture';
 
-export type SessionDecisionResponse = {
-  decision: 'allow' | 'deny';
-  reason: string;
-  timestamp: string;
-  remediation?: RemediationResult;
-};
-
-function buildResponse(
-  decision: SessionDecisionResponse['decision'],
-  reason: string,
-  remediation?: RemediationResult
-): SessionDecisionResponse {
-  return {
-    decision,
-    reason,
-    timestamp: new Date().toISOString(),
-    ...(remediation ? { remediation } : {}),
-  };
-}
-
-export function allow(reason: string, remediation?: RemediationResult): NextResponse<SessionDecisionResponse> {
-  return NextResponse.json(buildResponse('allow', reason, remediation), { status: 200 });
-}
-
-export function deny(reason: string, remediation?: RemediationResult): NextResponse<SessionDecisionResponse> {
-  return NextResponse.json(buildResponse('deny', reason, remediation), { status: 403 });
+export function createDeniedDeviceResponse() {
+  return NextResponse.json(
+    { success: false, decision: 'ACCESS_DENIED', error: 'Device non-compliant', code: 'DEVICE_NON_COMPLIANT' },
+    { status: 403 }
+  );
 }

--- a/src/lib/decision/engine.ts
+++ b/src/lib/decision/engine.ts
@@ -55,7 +55,7 @@ function policyEngine(
     return {
       decision: 'deny',
       reason: 'Risk score exceeds deny threshold',
-      decisionSource: 'baseline',
+      decisionSource: 'threshold',
       requiredActions: ['investigate_user', 'open_incident'],
     };
   }

--- a/src/lib/integrations/webhooks/dispatch.ts
+++ b/src/lib/integrations/webhooks/dispatch.ts
@@ -202,18 +202,24 @@ async function dispatchWithRetry(
 ): Promise<DeliveryResult> {
   let lastResult: DeliveryResult | null = null;
 
+  const isPermanentError = (result: DeliveryResult): boolean => {
+    if (result.statusCode && !isRetryableStatus(result.statusCode)) {
+      return true;
+    }
+
+    return (
+      result.error === 'Webhook signing secret not configured' ||
+      result.error === 'Invalid URL' ||
+      result.error === 'HTTPS required in production' ||
+      result.error === 'Localhost not allowed in production'
+    );
+  };
+
   for (let attempt = 1; attempt <= config.retry.maxAttempts; attempt++) {
     const result = await dispatchToEndpoint(webhook, payload, config);
     lastResult = result;
 
-    if (result.success) {
-      return result;
-    }
-
-    // Check if we should retry
-    const statusCode = result.statusCode;
-    if (statusCode && !isRetryableStatus(statusCode)) {
-      // Non-retryable error, stop here
+    if (result.success || isPermanentError(result)) {
       return result;
     }
 

--- a/tests/api/decision-evaluate.test.ts
+++ b/tests/api/decision-evaluate.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { evaluateDecisionFlow } from '@/lib/decision/engine';
 import { POST } from '@/app/api/decision/evaluate/route';
 
-const mockAppendAuditRecord = vi.fn();
+const { mockAppendAuditRecord } = vi.hoisted(() => ({
+  mockAppendAuditRecord: vi.fn(),
+}));
 
 vi.mock('@/lib/auditLedger', async () => {
   const actual = await vi.importActual<typeof import('@/lib/auditLedger')>('@/lib/auditLedger');


### PR DESCRIPTION
### Motivation
- Improve resilience and security of the session start pipeline by adding full request validation, rate limiting, and fail-closed posture handling. 
- Reduce wasted retry/backoff cycles for webhook deliveries when failures are permanent (e.g., missing signing secret or invalid URL).
- Fix decision engine metadata and test mocking issues that caused intermittent CI failures.

### Description
- Replace the lightweight posture-only `/api/session/start` handler with a full pipeline that performs signed-request validation via `validateAndAuthorizeSessionStart`, emits auth-failure audit/webhook events, enforces IP/device rate limits, checks badge enrollment/activity, supports existing-session extension, evaluates posture (unknown/non-compliant) and policy, creates sessions, applies policy actions (e.g., `launch_app`, `set_session_ttl`), and emits success audit/webhook events (changes in `src/app/api/session/start/route.ts`).
- Add posture service contracts `getFleetContext` and `getUEMContext` with safe fail-closed defaults used by the route (in `src/app/api/session/start/services/posture.ts`).
- Add a concrete denied-response helper for non-compliant device outcomes (`createDeniedDeviceResponse`) in `src/app/api/session/start/services/responses.ts`.
- Update webhook dispatcher retry logic to detect permanent errors (missing signing secret, invalid URL, HTTPS/localhost violations in production) and fail fast instead of exhausting exponential backoff (in `src/lib/integrations/webhooks/dispatch.ts`).
- Fix decision engine threshold labeling so deny-by-threshold reports `decisionSource: "threshold"` (in `src/lib/decision/engine.ts`).
- Fix vitest hoisted-mock initialization in `tests/api/decision-evaluate.test.ts` using `vi.hoisted` to avoid module-mocking initialization errors.

### Testing
- Ran typecheck and lint with `npm run typecheck` and `npm run lint`; both succeeded.
- Ran targeted tests with `npm run test:run -- tests/api/session-start-regression.test.ts tests/security/fail-closed-fallbacks.test.ts tests/api/decision-evaluate.test.ts`; all targeted tests passed (23 tests passed across those files).
- Ran broader test suites with `npm run test:run`; this surface-run showed pre-existing unrelated failures remain in other suites (examples: pagination/contract assertions, OpenAPI validation checks, some demo/integration tests that assume an externally managed server), which were not introduced by these changes.
- Performed a local server start during `npm run test:run:local` to validate runtime behavior; server started and endpoint health checks passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c42b534c832ebef34453ef7d9724)