### PR TITLE
Align SignalGrid messaging to frontline shared-device launch wedge

### DIFF
--- a/docs/ABOUT_SIGNALGRID.md
+++ b/docs/ABOUT_SIGNALGRID.md
@@ -1,18 +1,20 @@
 # About SignalGrid
 
 ## Short company description
-SignalGrid is the runtime decision layer between authentication and enforcement that resolves identity, device, and session risk before access breaks.
+SignalGrid is a shared-device access and runtime decision platform for frontline environments that resolves identity, device, and session risk before access breaks.
 
 ## Medium company description
-Modern enterprise stacks can authenticate identity, enforce policy, and visualize issues, but they still leave a critical gap between risk detection and final access outcome. SignalGrid fills that gap by evaluating identity, device posture, and session risk at runtime, attempting remediation when possible, re-evaluating trust, and returning a final access decision before disruption reaches the business.
+Modern enterprise stacks can authenticate identity, enforce policy, and visualize issues, but they still leave a critical gap between risk detection and final access outcome. SignalGrid fills that gap by evaluating identity, device posture, and session risk at runtime, attempting remediation when possible, re-evaluating trust, and returning a final access decision before disruption reaches the business. SignalGrid launches with high-friction shared-device workflows in frontline environments and can expand across industries where access, device posture, and operational continuity matter.
 
 ## Longer company description
 SignalGrid exists to close the decision gap between authentication and enforcement in modern enterprise environments. Today’s stacks are strong at verifying identity, managing endpoints, and observing failures, but they still leave operators with the same problem: when runtime conditions degrade, the common result is a block, a lockout, or a manual recovery process. SignalGrid adds a runtime decision layer that connects identity, device, and session signals, attempts remediation when possible, re-evaluates trust, and returns the correct final access outcome before disruption reaches the business.
 
+SignalGrid is built as a horizontal platform, with an intentional launch wedge in frontline, shared-device operating contexts where access continuity issues are frequent and costly.
+
 SignalGrid's core principle: access decisions should reflect runtime truth, not stale or incomplete signals.
 
 ## One-line product description
-SignalGrid is a runtime decision layer that evaluates identity, device, and session risk at session start, attempts remediation when possible, and returns a final access decision with audit context.
+SignalGrid is a shared-device access and runtime decision platform that evaluates identity, device, and session risk at session start, attempts remediation when possible, and returns a final access decision with audit context.
 
 ## Problem statement
 Authentication and enforcement are necessary, but they are not sufficient. When risk is detected, most systems either block access or rely on manual intervention. That creates lockouts, delays, and operational friction at exactly the moment when systems should be making the right decision automatically.

--- a/docs/FOUNDER_ONE_PAGER.md
+++ b/docs/FOUNDER_ONE_PAGER.md
@@ -4,10 +4,11 @@
 **SignalGrid**
 
 ## One-line product description
-SignalGrid is the runtime decision layer between authentication and enforcement that evaluates identity, device, and session risk, attempts remediation when possible, and returns a final access outcome with audit context.
+SignalGrid is a shared-device access and runtime decision platform between authentication and enforcement that evaluates identity, device, and session risk, attempts remediation when possible, and returns a final access outcome with audit context.
 
 ## Founder / investor blurb
 Modern security stacks are fragmented across identity, device, experience, and enforcement layers. Those systems can authenticate, configure, and observe—but they still do not own the decision of what happens next when runtime conditions degrade. SignalGrid is the runtime decision layer that unifies those signals, attempts remediation when possible, and determines the correct access outcome before disruption occurs.
+The initial launch wedge is frontline shared-device workflows where friction and downtime are most visible, with expansion potential across other industries over time.
 
 ## Problem
 Security and access teams often have the right controls but a broken flow at decision time:
@@ -48,6 +49,7 @@ SignalGrid sits between system-of-record and enforcement controls:
 In short: UEM tools show what is configured, DEX tools show what is failing, and SignalGrid decides what happens next before enforcement. SignalGrid is additive and does not replace IAM, UEM, DEX, or enforcement systems.
 
 ## Who it is for
+- Frontline environments with shared-device workflows, including healthcare and operations-heavy teams.
 - Identity and access teams.
 - Endpoint/UEM and mobility teams.
 - Security operations and Zero Trust program owners.

--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -13,16 +13,17 @@ Use it for:
 
 Most IT and security teams are overloaded by access-risk operations that still require human follow-up. Every manual review creates delay, inconsistency, and ticket backlog.
 
-SignalGrid is the runtime decision layer between authentication and enforcement. At session start, we evaluate identity, device, and session risk, attempt remediation when possible, re-check trust, and return a final access decision with an audit trail before users hit disruption.
+SignalGrid is a shared-device access and runtime decision platform between authentication and enforcement. At session start, we evaluate identity, device, and session risk, attempt remediation when possible, re-check trust, and return a final access decision with an audit trail before users hit disruption.
 
 We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. The practical outcome is faster decisions, less manual remediation work, and clearer accountability without rip-and-replace.
+We launch with frontline shared-device workflows where manual recovery and access friction are highest, then expand into adjacent workflows over time.
 Runtime truth matters: we have seen environments that still appear healthy while silently losing the ability to establish new TCP connections after prolonged uptime, forcing manual recovery and disruption.
 Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
 SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.
 
 ## Positioning Statement
 
-SignalGrid helps IT and security teams make runtime access decisions between authentication and enforcement by resolving identity, device, and session risk before access breaks.
+SignalGrid helps IT and security teams make shared-device runtime access decisions between authentication and enforcement by resolving identity, device, and session risk before access breaks.
 
 ## Ideal Customer Profile (ICP)
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,8 @@ export default function HomePage() {
             Fix Risk Before It Breaks Access
           </h1>
           <p className="max-w-3xl text-lg text-neutral-300">
-            SignalGrid is the runtime decision layer between authentication and enforcement that resolves identity,
-            device, and session risk before access breaks.
+            SignalGrid is a shared-device access and runtime decision platform for frontline environments that resolves
+            identity, device, and session risk before access breaks.
           </p>
         </header>
 
@@ -26,7 +26,8 @@ export default function HomePage() {
             <p className="mt-3 text-neutral-200">
               Modern enterprise environments can verify identity, enforce policy, and visualize issues, but they still
               leave a runtime decision gap. When risk is detected, most systems either block the user or rely on manual
-              remediation.
+              remediation. SignalGrid starts with high-friction frontline shared-device workflows and expands into other
+              industries where access continuity is mission-critical.
             </p>
           </article>
 


### PR DESCRIPTION
### Motivation
- Correct public and founder-facing messaging so SignalGrid is presented as a horizontal platform with a focused frontline/shared-device launch wedge rather than an overly broad "for every industry" claim. 
- Keep product scope and MVP boundaries unchanged while making the launch positioning credible and actionable for sales/outreach. 
- Make a minimal, targeted wording pass limited to docs and the homepage to avoid reopening broader product or architecture work.

### Description
- Updated core positioning language to describe SignalGrid as a `shared-device access and runtime decision platform` in `docs/ABOUT_SIGNALGRID.md` and `src/app/page.tsx`. 
- Clarified launch sequencing and added frontline/shared-device launch wedge language in `docs/FOUNDER_ONE_PAGER.md` and `docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md`. 
- Added a short callout about frontline/shared-device contexts (including healthcare-adjacent examples) in the founder one-pager without changing MVP scope or feature claims. 
- Changes are messaging-only; no codepaths, APIs, or product behavior were modified.

### Testing
- Ran the repository linter with `npm run lint`, which completed successfully (exit code 0). 
- No unit, e2e, or integration tests were modified or required for this wording-only change. 
- No blockers were encountered during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc58d0df38832ebc5a993b76f48a64)