### PR TITLE
Final messaging alignment pass for SignalGrid launch positioning

### DIFF
--- a/docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md
+++ b/docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md
@@ -9,6 +9,7 @@ Hi {{FirstName}},
 Thank you for reaching out and for your interest in SignalGrid.
 
 SignalGrid is the runtime decision layer between authentication and enforcement. It evaluates identity, device, and session risk at runtime, attempts remediation when possible, re-evaluates trust, and returns a final access decision before workflows are disrupted. We are currently in MVP closed-loop launch mode, focused on a narrow session-start use case.
+Our launch wedge is frontline shared-device workflows where posture, runtime conditions, and access continuity matter most.
 Our core principle is simple: access decisions should reflect runtime truth, not stale or incomplete signals.
 
 We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. We do not replace IAM, UEM, DEX, or enforcement systems.

--- a/docs/FOUNDER_ONE_PAGER.md
+++ b/docs/FOUNDER_ONE_PAGER.md
@@ -18,6 +18,7 @@ Security and access teams often have the right controls but a broken flow at dec
 - When risk is found, users and operators still fall into manual, slow remediation paths.
 
 The gap is the runtime loop between authentication, remediation attempt, and final outcome before workflow disruption.
+In practice, trust troubleshooting (such as certificate, Wi-Fi, or VPN access-path issues) is still manual and admin-heavy, which reinforces the need for runtime classification, remediation, and outcome control.
 
 ## Solution
 SignalGrid runs in the runtime decision path between authentication and enforcement before access proceeds:

--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -12,6 +12,8 @@ Scope for this checklist: **only** the MVP closed-loop launch (detect issue → 
 ## Website readiness
 
 - [ ] Homepage clearly positions SignalGrid as a closed-loop decision layer for identity/device/session risk.
+- [ ] Messaging states SignalGrid sits between authentication and enforcement.
+- [ ] Launch narrative is explicitly focused on frontline/shared-device workflows (with broader expansion framed as future direction).
 - [ ] CTA/contact path is live and tested end-to-end.
 - [ ] Copy stays within MVP launch scope (no post-MVP claims).
 - [ ] Launch deployment is stable.
@@ -50,4 +52,3 @@ Scope for this checklist: **only** the MVP closed-loop launch (detect issue → 
 ## Cutover reference
 
 - See `docs/CODEX_COMPLETE_CUTOVER_CHECKLIST.md` for the final Codex-complete and manual-only handoff sequence, including PR #72 cleanup.
-

--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -13,10 +13,10 @@ Use it for:
 
 Most IT and security teams are overloaded by access-risk operations that still require human follow-up. Every manual review creates delay, inconsistency, and ticket backlog.
 
-SignalGrid is a shared-device access and runtime decision platform between authentication and enforcement. At session start, we evaluate identity, device, and session risk, attempt remediation when possible, re-check trust, and return a final access decision with an audit trail before users hit disruption.
+SignalGrid is a shared-device access and runtime decision platform that sits between authentication and enforcement. At session start, we evaluate identity, device, and session risk, attempt remediation when possible, re-check trust, and return a final access decision with an audit trail before users hit disruption.
 
 We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. The practical outcome is faster decisions, less manual remediation work, and clearer accountability without rip-and-replace.
-We launch with frontline shared-device workflows where manual recovery and access friction are highest, then expand into adjacent workflows over time.
+We launch with frontline shared-device workflows where manual recovery and access friction are highest, then expand into adjacent industries over time.
 Runtime truth matters: we have seen environments that still appear healthy while silently losing the ability to establish new TCP connections after prolonged uptime, forcing manual recovery and disruption.
 Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
 SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.

--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -17,6 +17,7 @@ SignalGrid is a shared-device access and runtime decision platform that sits bet
 
 We are additive to existing controls: UEM tools show what’s configured, DEX tools show what’s failing, and SignalGrid decides what happens next. The practical outcome is faster decisions, less manual remediation work, and clearer accountability without rip-and-replace.
 We launch with frontline shared-device workflows where manual recovery and access friction are highest, then expand into adjacent industries over time.
+Today, trust troubleshooting (including certificate, Wi-Fi, or VPN-related access failures) is often manual and fragmented; SignalGrid helps move those operations toward runtime classification, remediation, and outcome control.
 Runtime truth matters: we have seen environments that still appear healthy while silently losing the ability to establish new TCP connections after prolonged uptime, forcing manual recovery and disruption.
 Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
 SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,8 +26,8 @@ export default function HomePage() {
             <p className="mt-3 text-neutral-200">
               Modern enterprise environments can verify identity, enforce policy, and visualize issues, but they still
               leave a runtime decision gap. When risk is detected, most systems either block the user or rely on manual
-              remediation. SignalGrid starts with high-friction frontline shared-device workflows and expands into other
-              industries where access continuity is mission-critical.
+              remediation. SignalGrid launches with high-friction frontline shared-device workflows and later expands
+              into additional industries where access continuity is mission-critical.
             </p>
           </article>
 


### PR DESCRIPTION
### Motivation
- Ensure public-facing copy and docs consistently reflect the MVP launch truth: SignalGrid is a runtime decision layer that sits between authentication and enforcement and is launching focused on frontline/shared-device workflows. 
- Avoid present-tense overclaiming about broad industry coverage or replacement of IAM/UEM/DEX by framing expansion as a future direction. 

### Description
- Updated homepage wording in `src/app/page.tsx` to change “starts… and expands” to a clearer launch vs future phrasing: “launches with frontline shared-device workflows and later expands into additional industries.”
- Adjusted `docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md` to use the exact phrasing that SignalGrid “sits between authentication and enforcement” and to clarify expansion language to “adjacent industries.”
- Added a launch-wedge sentence to `docs/EARLY_ACCESS_RESPONSE_TEMPLATE.md` to call out frontline shared-device workflows as the launch focus. 
- Added checklist items to `docs/LAUNCH_CHECKLIST.md` to explicitly require website messaging to state the between-auth-and-enforcement positioning and to frame broader expansion as future direction; no product logic or functional code changes were made. 

### Testing
- Ran linting via `npm run lint` and it completed successfully. 
- No other automated tests were required for this documentation-only alignment pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb8c37cec832e8eae548e6caea4fe)