### PR TITLE
Refine sales narrative with capability-first positioning

### DIFF
--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -22,9 +22,29 @@ Runtime truth matters: we have seen environments that still appear healthy while
 Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
 SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.
 
+## Strategic Reframe: Function vs Capability
+
+Many teams still run access operations as a **reactive function**:
+
+Access attempt → failure → ticket → troubleshooting → recovery.
+
+SignalGrid shifts this to an **embedded service capability**:
+
+Access attempt → detect risk → decide → remediate → verify outcome.
+
+This matters because resolution is built directly into the access flow itself, so issues are handled before they become user-visible disruptions.
+
 ## Positioning Statement
 
 SignalGrid helps IT and security teams make shared-device runtime access decisions between authentication and enforcement by resolving identity, device, and session risk before access breaks.
+
+## Board-Level Positioning Option
+
+SignalGrid embeds decisioning and remediation directly into access workflows so issues are resolved before they become operational disruptions.
+
+## One-Line Explanation (Buyer-Friendly)
+
+SignalGrid embeds decision and remediation directly into access workflows, so failures are resolved before users are impacted.
 
 ## Ideal Customer Profile (ICP)
 
@@ -47,6 +67,7 @@ SignalGrid helps IT and security teams make shared-device runtime access decisio
 - “What prompted you to take this conversation now?”
 - “If this works, what changes for your team in the next 90 days?”
 - “Which metric matters most: cycle time, ticket volume, compliance consistency, or analyst time?”
+- “Where does your process still depend on reactive support after users are already impacted?”
 
 ### 2) Current Workflow Reality (6–8 min)
 - “Walk me through one recurring workflow from trigger to closure.”
@@ -54,6 +75,7 @@ SignalGrid helps IT and security teams make shared-device runtime access decisio
 - “How often do exceptions or retries happen?”
 - “How do you currently audit who approved what and why?”
 - “Where do authentication checks end and enforcement begin today?”
+- “What parts of remediation are outside the access flow today?”
 
 ### 3) Risk and Constraints (4–6 min)
 - “What is the failure mode you’re most worried about?”
@@ -64,6 +86,7 @@ SignalGrid helps IT and security teams make shared-device runtime access decisio
 - “Which one workflow would be highest-value but low-risk for a pilot?”
 - “What baseline metric should we compare against?”
 - “Who needs to be involved for technical sign-off and business sign-off?”
+- “What reduction in post-failure tickets would make this pilot a clear win?”
 
 ## Discovery Scorecard
 

--- a/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
+++ b/docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md
@@ -22,17 +22,17 @@ Runtime truth matters: we have seen environments that still appear healthy while
 Authentication proves identity; SignalGrid ensures the system is actually capable of operating before access is granted.
 SignalGrid ensures access decisions are based on runtime truth, not stale or incomplete signals.
 
-## Strategic Reframe: Function vs Capability
+## Strategic Reframe: Feature vs System
 
-Many teams still run access operations as a **reactive function**:
+Most teams still implement access like a **feature**:
 
 Access attempt → failure → ticket → troubleshooting → recovery.
 
-SignalGrid shifts this to an **embedded service capability**:
+SignalGrid treats access as a **runtime system**:
 
 Access attempt → detect risk → decide → remediate → verify outcome.
 
-This matters because resolution is built directly into the access flow itself, so issues are handled before they become user-visible disruptions.
+This matters because real environments are stateful and failure-prone. Resolution has to be built into the flow, not bolted on after disruption.
 
 ## Positioning Statement
 
@@ -40,11 +40,17 @@ SignalGrid helps IT and security teams make shared-device runtime access decisio
 
 ## Board-Level Positioning Option
 
-SignalGrid embeds decisioning and remediation directly into access workflows so issues are resolved before they become operational disruptions.
+Most access systems are built like features. SignalGrid treats access as a runtime system, so issues are resolved before they become operational disruptions.
 
 ## One-Line Explanation (Buyer-Friendly)
 
-SignalGrid embeds decision and remediation directly into access workflows, so failures are resolved before users are impacted.
+SignalGrid treats access and security as a runtime system, not a static feature.
+
+## Technical Conversation Bridge (Use with senior engineers)
+
+- “Most organizations treat access control like a feature. In production, it behaves like a system problem with state, retries, and failure paths.”
+- “SignalGrid adds runtime decision + remediation loops so outcome correctness is maintained when signals are stale, partial, or contradictory.”
+- “The goal is not more alerts. The goal is correct access outcomes under real conditions.”
 
 ## Ideal Customer Profile (ICP)
 
@@ -76,11 +82,13 @@ SignalGrid embeds decision and remediation directly into access workflows, so fa
 - “How do you currently audit who approved what and why?”
 - “Where do authentication checks end and enforcement begin today?”
 - “What parts of remediation are outside the access flow today?”
+- “Where do failures happen because systems disagree in runtime, even though pre-checks looked fine?”
 
 ### 3) Risk and Constraints (4–6 min)
 - “What is the failure mode you’re most worried about?”
 - “What approval boundaries are non-negotiable?”
 - “Any integration, change-management, or procurement blockers we should design around?”
+- “If we treated this as a system reliability problem, what failure path would you fix first?”
 
 ### 4) Pilot Shape (5–8 min)
 - “Which one workflow would be highest-value but low-risk for a pilot?”


### PR DESCRIPTION
### Motivation
- Clarify SignalGrid’s positioning by reframing access operations from a reactive function to an embedded service capability so sales conversations and pilot framing emphasize proactive resolution inside access flows.
- Provide succinct, board- and buyer-friendly language to make the core value easier to communicate in executive and discovery contexts.
- Surface discovery questions that reveal where customers still rely on reactive support and what ticket-reduction outcomes would make a pilot compelling.

### Description
- Added a new "Strategic Reframe: Function vs Capability" section that contrasts reactive workflows with SignalGrid’s embedded remediation flow in `docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md`.
- Introduced a "Board-Level Positioning Option" and a concise "One-Line Explanation (Buyer-Friendly)" aligned to proactive decisioning and remediation messaging.
- Expanded the Discovery Flow prompts to include questions that surface dependence on reactive support, remediation gaps outside the access flow, and pilot ticket-reduction targets.
- Updated `docs/SALES_NARRATIVE_AND_DISCOVERY_SCRIPT.md` with ~23 lines of additions supporting the above messaging.

### Testing
- Ran `git diff --check` to validate whitespace/diff issues and the check completed successfully.
- Committed the change and created the PR; no additional automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1071ad074832e907c367dfe8a3029)