### PR TITLE
docs: finalize SignalGrid readiness hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      npm-production:
+        dependency-type: "production"
+      npm-development:
+        dependency-type: "development"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md) for the evolv
 ## Current repository status
 
 - **Demo-ready**: Yes — includes demo control scripts, demo validation flow, and demo-oriented tests.
-- **Pilot-ready**: In progress — production hardening and operational maturity work are tracked in roadmap docs.
+- **Pilot-ready**: In progress — production hardening, Docker validation in a Docker-capable environment, and operational maturity work are tracked in roadmap docs.
 
 ## Repository structure
 
@@ -145,13 +145,13 @@ Additional script options are available in `package.json` for API tests, securit
 
 ## Production operations
 
-SignalGrid now includes a production container path and launch runbook for operating the product as a managed service or customer-hosted deployment. See [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for release gates, required environment variables, container deployment, health checks, and incident rollback steps.
+SignalGrid includes a production container path and launch runbook for operating the product as a managed service or customer-hosted deployment after target-environment validation. See [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for release gates, required environment variables, container deployment, health checks, and incident rollback steps. Docker build/run commands should be validated in a Docker-capable environment before customer deployment.
 
 The public integration compatibility surface is available under `/api/v1/*` for health, devices, events, metrics, session start, and location reporting workflows.
 
 ## Security note
 
-Demo and development paths are intentionally optimized for speed and validation. They are not equivalent to hardened production controls. Production deployment requires strict key management, signed data paths, environment hardening, and operational guardrails.
+Demo and development paths are intentionally optimized for speed and validation. They are not equivalent to hardened production controls, and demo outputs are simulated unless explicitly configured otherwise. Production deployment requires strict key management, signed data paths, environment hardening, operational guardrails, and signed pilot or customer deployment scope. See [docs/DISCLAIMER.md](docs/DISCLAIMER.md).
 
 ## Roadmap preview
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,103 +1,137 @@
-# Security Policy
+# SignalGrid Security Policy
 
-## Security Baseline
+## Security baseline
 
-This document outlines the security requirements and assumptions for the EnterpriseShell kiosk application.
+This document outlines the security requirements and operating assumptions for SignalGrid, a runtime trust-decisioning and orchestration platform for shared and mobile work environments.
 
-### No Secrets in Repository
+### No secrets in repository
 
-- **Never commit** API keys, tokens, certificates, or credentials to this repository
-- Use environment variables for all sensitive configuration
-- Store secrets in the iOS Keychain with `kSecAttrAccessibleThisDeviceOnly`
-- Backend service URLs should be configurable via `ProviderConfigurationService`
+- **Never commit** API keys, tokens, certificates, signing secrets, private keys, customer credentials, or production data to this repository.
+- Use environment variables or an approved secrets manager for all sensitive runtime configuration.
+- Treat `BACKEND_SIGNING_SECRET`, `INTEGRATION_SIGNING_SECRET`, `ADMIN_API_KEY`, OIDC configuration, Redis credentials, and customer integration credentials as production secrets.
+- Use separate demo, staging, pilot, and production secrets; never reuse demo secrets for customer environments.
+- Do not enter real customer secrets or regulated production data into demo flows.
 
-### HTTPS Required
+### HTTPS and signed API paths
 
-- All network communication MUST use TLS 1.2 or higher
-- Certificate pinning should be implemented for production deployments
-- HTTP Strict Transport Security (HSTS) headers should be enforced by the backend
+- All production network communication **must** use HTTPS with TLS 1.2 or higher.
+- Production device, session, event, and integration ingestion paths must require HMAC signatures where supported by the runtime API contract.
+- HMAC verification should include timestamp and nonce protections to reduce replay risk.
+- Signing secrets must be rotated when exposure is suspected and should be rotated on a defined customer or operator cadence.
+- HTTP Strict Transport Security (HSTS) headers should be enforced by the production edge or hosting layer.
+- Certificate pinning may be required for future managed mobile clients or high-assurance customer deployments.
 
-### Logging Policy
+### Runtime decisioning and fail-closed behavior
 
-- **Never log** raw badge identifiers, user IDs, or PII in production
-- Audit logs should use masked/hashed identifiers
-- Session tokens should never appear in logs
-- Log levels should be configurable (debug, info, warning, error)
+- SignalGrid trust decisions should be explicit, deterministic, and auditable: `ALLOW`, `DENY`, or `STEP_UP`.
+- Production policy evaluation must fail closed for missing required inputs, invalid signatures, expired timestamps, replayed nonces, unknown devices, malformed payloads, and unavailable critical trust dependencies.
+- Demo and simulation paths may return representative decisions for validation, but they must be clearly separated from production mode.
+- Destructive or enforcement-capable integrations must remain disabled unless explicitly configured and authorized for the target environment.
 
-Example (mask badge ID):
-```swift
-// Instead of: logger.info("Badge scanned: \(badgeId)")
-logger.info("Badge scanned: ***\(String(badgeId.suffix(4)))")
+### Demo and simulated API safety
+
+- Demo outputs, seeded personas, simulated device posture, badge events, location reports, and integration responses are simulated unless the environment is explicitly configured otherwise.
+- Demo mode is for evaluation, validation, and storytelling only; it is not a production security boundary.
+- Demo environments must not collect, store, or transmit real customer secrets, regulated production data, or live credentials.
+- Production deployments must keep `DEMO_MODE=false`, `ENABLE_DEV_BYPASS=false`, and `ENABLE_DESTRUCTIVE_ACTIONS=false` unless a signed customer change request explicitly authorizes a different setting.
+
+### Logging, auditability, and event traceability
+
+- **Never log** raw secrets, signing keys, session tokens, customer credentials, raw badge identifiers, or unnecessary PII.
+- Audit and event records should use masked, hashed, or opaque identifiers when possible.
+- Security-relevant events should be traceable across request receipt, signature validation, policy evaluation, decision output, integration action, and operator/customer review.
+- Audit trails should preserve decision inputs and outcomes at an appropriate level of detail without exposing secrets or sensitive payload contents.
+- Log levels should be configurable and production logging should avoid debug-level sensitive context.
+
+Example masking pattern:
+
+```ts
+// Instead of logging a full badge, token, or customer identifier:
+logger.info({ badgeSuffix: badgeId.slice(-4) }, "Badge event received");
 ```
 
-### Threat Model Assumptions
+### Agent and operator guardrails
 
-This application is designed for the following deployment scenario:
+- Agents, scripts, and operators must not bypass production authentication, signing, or policy checks outside an explicitly approved break-glass procedure.
+- Automation should prefer read-only or advisory operation unless enforcement has been reviewed, tested, and authorized.
+- Generated reports, demo artifacts, and screenshots must be reviewed before sharing externally to avoid leaking internal paths, secrets, or customer-specific information.
+- Use least-privilege access for admin APIs, CI jobs, deployment tokens, and integration credentials.
 
-1. **Supervised Device**: iOS devices are in Single App Mode or Guided Access
-2. **Kiosk Environment**: Devices are in public-facing or controlled-access locations
-3. **Physical Security**: Devices are physically secured (locked enclosure, tamper detection)
-4. **Network Security**: Devices operate on trusted networks behind corporate firewalls
-5. **User Intent**: Users are authorized employees badge-in for work sessions
+### Threat model assumptions
 
-### Security Requirements
+SignalGrid is designed for deployments where:
 
-- [ ] Certificate pinning implemented in `BackendService`
-- [ ] Device binding to prevent token hijacking
-- [ ] Rate limiting on authentication attempts (5 attempts/minute, 5-minute lockout)
-- [ ] Session timeout enforcement (configurable, default 8 hours)
-- [ ] Audit logging for all security events
-- [ ] Jailbreak detection (optional, with graceful degradation)
-- [ ] Ephemeral URLSession for authentication flows
+1. **Identity context exists**: Customer identity, role, or badge systems provide user/session signals.
+2. **Device context exists**: Device posture, enrollment, or managed-state signals are available from customer systems or approved integrations.
+3. **Runtime context matters**: Location, shift, risk, operational state, and workflow context can change the access decision.
+4. **Enforcement is downstream**: SignalGrid orchestrates or advises connected systems rather than replacing IAM, UEM/MDM, NAC, SIEM, DEX, ITSM, or endpoint controls.
+5. **Auditability is required**: Customers and operators need decision receipts, event traces, and integration evidence.
+6. **Demo paths are isolated**: Simulated data and demo modes are not used as production controls.
 
-### Reporting Security Issues
+### Security requirements
+
+- [ ] No committed secrets, credentials, production customer data, or regulated sample data.
+- [ ] HTTPS enforced for production traffic.
+- [ ] HMAC request signing enabled and validated on production ingestion/API paths that require it.
+- [ ] Timestamp, nonce, and replay protections enabled for signed requests.
+- [ ] Fail-closed handling verified for invalid signatures, missing context, unknown devices, dependency failures, and malformed payloads.
+- [ ] Audit/event traceability tested from request through decision and integration action.
+- [ ] Rate limiting enabled for authentication, session, ingestion, and admin-sensitive paths.
+- [ ] Admin access protected by OIDC or a documented temporary break-glass control.
+- [ ] Demo bypasses and destructive actions disabled in production.
+- [ ] Dependency vulnerability scanning and update review enabled.
+
+### Security checklist before pilot or production deployment
+
+- [ ] All environment variables and secrets provisioned through approved secure channels.
+- [ ] Production `.env` files excluded from source control and artifact uploads.
+- [ ] `DEMO_MODE=false`, `ENABLE_DEV_BYPASS=false`, and `ENABLE_DESTRUCTIVE_ACTIONS=false` confirmed.
+- [ ] Signing secrets generated with sufficient entropy and documented rotation procedures.
+- [ ] HMAC happy-path, invalid-signature, stale-timestamp, and replay tests passed.
+- [ ] Audit logging enabled and reviewed for redaction quality.
+- [ ] Customer-specific retention, export, and deletion expectations documented.
+- [ ] Incident rollback and signing-secret rotation process rehearsed.
+- [ ] Dependency updates reviewed and release gates passed.
+
+### Data classification
+
+| Data Type | Classification | Handling |
+| --- | --- | --- |
+| Signing secrets and API keys | Secret | Store only in approved secrets systems; never log. |
+| Session tokens and admin JWTs | Secret | Never log; enforce expiration and least privilege. |
+| Raw badge or user identifiers | Sensitive/PII | Avoid storing; mask or hash for audit where possible. |
+| Device identifiers and posture | Customer internal | Minimize collection; retain only what supports decisions and audit. |
+| Policy decisions and receipts | Customer internal | Preserve for audit; redact sensitive inputs. |
+| Demo personas and simulated outputs | Demo data | Clearly label as simulated; do not mix with customer production data. |
+| Audit/event logs | Customer internal | Protect at rest and in transit; retain according to customer/operator policy. |
+
+### Dependency security
+
+- Run `npm audit` or an equivalent dependency scanner before release when feasible.
+- Keep dependencies current through reviewed update pull requests.
+- Review lockfile changes and transitive dependency risk before merging updates.
+- Use Dependabot or comparable automation for update visibility.
+- Track security findings to remediation or documented risk acceptance.
+
+### Future/mobile-client considerations
+
+The repository may include iOS prototype or mobile-client artifacts. The following controls apply to future mobile-client work and high-assurance deployments, not necessarily to the current web/API MVP:
+
+- Store mobile tokens and device-bound secrets in the platform keychain or secure enclave where supported.
+- Use managed-device controls such as MDM/UEM profiles, app allow-listing, remote wipe, and supervised mode where customer policy requires them.
+- Consider certificate pinning for managed production mobile clients.
+- Consider jailbreak/root detection with graceful degradation and customer-approved user messaging.
+- Consider Single App Mode, Guided Access, or equivalent kiosk controls for supervised shared-device deployments.
+
+### Reporting security issues
 
 If you discover a security vulnerability, please report it responsibly:
 
-1. Do NOT create a public GitHub issue
-2. Contact the security team directly
-3. Provide details but no PoC code
-4. Allow time for remediation before disclosure
-
-### Security Checklist (Pre-Deployment)
-
-- [ ] All secrets removed from source code
-- [ ] HTTPS enforced in production
-- [ ] Certificate pinning configured
-- [ ] Audit logging enabled and tested
-- [ ] Session timeout configured appropriately
-- [ ] Rate limiting enabled
-- [ ] Keychain configured with `ThisDeviceOnly`
-- [ ] Single App Mode / Guided Access enabled
-- [ ] MDM profiles deployed
-- [ ] Physical security in place
-
-### Data Classification
-
-| Data Type | Classification | Handling |
-|-----------|---------------|----------|
-| Badge ID (raw) | PII | Never log or store |
-| Badge ID (masked) | Internal | Hash before audit |
-| User ID | PII | Hash before audit |
-| Session Token | Secret | Keychain only |
-| Persona Data | Internal | Encrypted at rest |
-| Audit Logs | Internal | Retained 90 days |
-
-### Dependency Security
-
-- Regularly run `npm audit` or `bun audit`
-- Keep dependencies up to date
-- Review dependency changes before updating
-- Use Dependabot for automated updates
-
-### Mobile Device Management (MDM)
-
-- MDM payload should enforce:
-  - Password policies
-  - App allow-listing
-  - Network restrictions
-  - Remote wipe capability
+1. Do **not** create a public GitHub issue.
+2. Contact the project maintainers or security owner directly through the approved private channel.
+3. Provide enough detail to reproduce and assess the issue, but avoid sharing exploit code publicly.
+4. Allow reasonable time for triage and remediation before disclosure.
 
 ---
 
-*Last Updated: 2026-02-17*
+*Last updated: 2026-05-12*

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -1,0 +1,27 @@
+# SignalGrid Disclaimer
+
+SignalGrid is an MVP-stage product and this repository contains demo, simulation, validation, and production-readiness materials. Use the guidance below when reviewing, demonstrating, or deploying the project.
+
+## Demo and simulation scope
+
+- Demo outputs are simulated unless the environment is explicitly configured and documented to use live customer systems.
+- Demo personas, badge events, device posture, locations, policy responses, downstream actions, and integration responses are representative examples for validation and storytelling.
+- Demo flows must not be treated as evidence that a specific customer integration, enforcement action, or production security control is active.
+
+## Commercial and deployment status
+
+- SignalGrid is MVP/pre-commercial unless it is deployed under a signed pilot, proof-of-concept, or production agreement.
+- A signed pilot or deployment agreement should define environment boundaries, customer systems, data handling, security responsibilities, operational support, success criteria, and rollback procedures.
+- Production operation requires the release gates, security controls, and runbook steps documented in this repository to be validated for the target environment.
+
+## Relationship to existing enterprise systems
+
+- SignalGrid does **not** replace IAM, UEM/MDM, DEX, NAC, SIEM, ITSM, endpoint security, or customer system-of-record platforms.
+- SignalGrid is intended to orchestrate runtime trust decisions and downstream actions using signals and controls from those systems.
+- Customers remain responsible for configuring and operating their identity, device-management, endpoint, network, observability, and compliance systems.
+
+## Data and secrets warning
+
+- Do **not** enter real customer secrets, production credentials, regulated data, patient data, employee records, or other sensitive production data into demo flows.
+- Do not reuse demo secrets in staging, pilot, or production environments.
+- Review generated reports, screenshots, logs, and exported demo artifacts before sharing externally.

--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -1,6 +1,6 @@
 # SignalGrid Production Runbook
 
-This runbook is the operating baseline for selling and running SignalGrid as a managed product or customer-hosted service.
+This runbook is the operating baseline for piloting or running SignalGrid as a managed product or customer-hosted service after the target environment, customer scope, and release gates have been validated.
 
 ## Release gates
 
@@ -38,14 +38,14 @@ Keep `ENABLE_DEV_BYPASS=false`, `ENABLE_DESTRUCTIVE_ACTIONS=false`, and `DEMO_MO
 
 ## Container deployment
 
-Build and run the standalone production container:
+Build and run the standalone production container. These commands must be validated in a Docker-capable environment before relying on them for a customer deployment:
 
 ```bash
 docker build -t signalgrid:latest .
 docker run --rm -p 3000:3000 --env-file .env.production signalgrid:latest
 ```
 
-The container runs as a non-root `signalgrid` user and serves the Next.js standalone build from `server.js`.
+The Dockerfile is intended to run as a non-root `signalgrid` user and serve the Next.js standalone build from `server.js`; confirm this behavior during Docker-capable release validation.
 
 ## Health and compatibility endpoints
 
@@ -62,6 +62,7 @@ The container runs as a non-root `signalgrid` user and serves the Next.js standa
 5. Smoke test `/api/health`, `/api/v1/health`, session start, location report, and one denied-risk path.
 6. Enable monitoring on health status, 401/403 spikes, rate-limit spikes, integration DLQ depth, and webhook retry count.
 7. Keep the first customer rollout in shadow or advisory mode until the customer signs off on enforcement actions.
+8. Confirm demo and production modes remain separated, with simulated demo data excluded from customer production workflows.
 
 ## Incident rollback
 


### PR DESCRIPTION
### Motivation
- Rebrand and reframe repository security and readiness materials from an iOS/EnterpriseShell prototype into a company-level SignalGrid posture focused on runtime decisioning, signing, auditability, and demo safety.
- Make demo/production boundaries explicit and reduce the chance of accidental production data or secrets entering demo flows.
- Improve dependency update visibility and provide a clear, conservative cadence for automated updates.

### Description
- Rewrote `SECURITY.md` to a SignalGrid-focused security baseline that calls out no-commit secret rules, HTTPS and HMAC-signed API path expectations, fail-closed runtime decisioning (`ALLOW`/`DENY`/`STEP_UP`), demo/simulation safety, logging/audit traceability, agent/operator guardrails, and pilot/production checklists.
- Added `docs/DISCLAIMER.md` to state demo outputs are simulated unless explicitly configured, declare MVP/pre-commercial status absent a signed pilot, clarify SignalGrid does not replace IAM/UEM/DEX systems, and warn against entering real customer secrets into demos.
- Added `.github/dependabot.yml` to enable monthly npm dependency updates with `dependencies`/`security` labels and grouped production/development visibility.
- Toned README.md and `docs/PRODUCTION_RUNBOOK.md` language to avoid overclaiming production readiness, require Docker-capable validation for the build/run instructions, and reinforce separation of demo and production modes; files changed: `SECURITY.md`, `docs/DISCLAIMER.md`, `.github/dependabot.yml`, `README.md`, and `docs/PRODUCTION_RUNBOOK.md`.

### Testing
- Ran `git diff --check` and it reported no whitespace/patch issues, indicating no obvious formatting errors in the edits.
- Validated `.github/dependabot.yml` with a small YAML check (`ruby -e '...YAML.load_file(".github/dependabot.yml")'`), which succeeded and confirmed `package-ecosystem: npm` and `version: 2` were present.
- Ran `npm run lint` and the lint step completed without errors relevant to the changed README/runbook/docs content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029c8d2fb0832eadf98005d5312643)