### PR TITLE
docs: polish business-facing repo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Identity + Badge + Device/Posture + Location Context
 
 See [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md) for the evolving architecture model.
 
+## Business-facing docs
+
+- [Claim boundaries](docs/CLAIM_BOUNDARIES.md) — safe language for MVP, demo, pilot, and production claims.
+- [Value map](docs/VALUE_MAP.md) — executive, IT/security, workflow, audit, and pilot-metric mapping.
+- [Product board](docs/PRODUCT_BOARD.md) — current MVP, demo confidence, pilot readiness, future roadmap, and non-goals.
+- [Integration priorities](docs/INTEGRATION_PRIORITIES.md) — current demo integrations, first real targets, later targets, and safety boundaries.
+- [Architecture future notes](docs/ARCHITECTURE_FUTURE_NOTES.md) — future gateway, remediation, AI-assist, guardrails, and non-goals.
+
 ## Current repository status
 
 - **Demo-ready**: Yes — includes demo control scripts, demo validation flow, and demo-oriented tests.

--- a/docs/ARCHITECTURE_FUTURE_NOTES.md
+++ b/docs/ARCHITECTURE_FUTURE_NOTES.md
@@ -1,3 +1,57 @@
-# Architecture Future Notes
+# SignalGrid Architecture Future Notes
 
-(Your content here)
+These notes describe future architecture direction. They are not current production claims.
+
+## Event-driven decision gateway direction
+
+SignalGrid should evolve toward an event-driven decision gateway that:
+
+- Receives signed events from badge, identity, posture, location, and session sources.
+- Normalizes context into a consistent policy input.
+- Produces explicit decisions such as allow, deny, step-up, quarantine request, or ticket request.
+- Emits auditable decision records and downstream integration events.
+- Keeps customer-specific integrations behind well-defined adapters.
+
+The gateway should remain deterministic and explainable for high-consequence frontline workflows.
+
+## Constrained remediation playbooks
+
+Future remediation should be modeled as bounded playbooks, not open-ended automation. A safe playbook should include:
+
+- Trigger conditions and required input fields.
+- Allowed actions and disallowed actions.
+- Approval requirements for high-risk steps.
+- Timeout, retry, and rollback behavior.
+- Re-check criteria before access is allowed.
+- Audit records for `attempted`, `succeeded`, `failed`, and `final decision` states.
+
+## AI-assisted explanation/classification
+
+AI-assisted capabilities may be useful later for summarizing decision context, classifying event patterns, or drafting operator-facing explanations. These should remain future-only until guardrails are implemented.
+
+Any AI-assisted workflow must:
+
+- Avoid autonomous high-risk enforcement.
+- Use structured inputs and bounded outputs.
+- Preserve policy-engine authority for final decisions.
+- Cite the signals and rules behind generated explanations.
+- Fail closed or require review when confidence is low or inputs are incomplete.
+- Avoid exposing secrets, credentials, or unnecessary personal data.
+
+## Guardrails
+
+Future architecture work should preserve these guardrails:
+
+- Signed inputs for security-sensitive events.
+- Explicit environment configuration with no shared-stage or production default secrets.
+- Least-privilege integration credentials.
+- Clear separation between demo simulation and production code paths.
+- Auditable policy decisions and integration actions.
+- Deterministic fallback behavior for missing, stale, or conflicting signals.
+
+## Non-goals
+
+- Replacing customer IAM, UEM/MDM, DEX, NAC, SIEM, SOAR, or ITSM platforms.
+- Building a generic autonomous agent that can take unrestricted external actions.
+- Treating AI-generated explanations as policy decisions.
+- Making production-readiness claims before deployment validation, load testing, and customer-specific integration review are complete.

--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,3 +1,68 @@
-# Claim Boundaries
+# SignalGrid Claim Boundaries
 
-(Your content here)
+SignalGrid should be described with clear MVP/demo boundaries. Use this document when preparing website copy, demos, sales materials, investor notes, or partner outreach.
+
+## What SignalGrid can claim today
+
+SignalGrid can credibly claim that it:
+
+- Provides a working MVP/demo path for posture-aware shared-device session decisions.
+- Evaluates identity, device posture, session context, and policy inputs before returning an access outcome.
+- Demonstrates deterministic outcomes for compliant, non-compliant, and unknown-posture scenarios.
+- Fails closed for unknown posture in the current session-start path unless an explicit local/demo override is configured.
+- Produces auditable decision context and demo-visible integration/action records.
+- Includes simulated/demo workflows for NAC, SIEM, ITSM, and remediation-oriented narratives.
+- Includes production-oriented packaging and runbook foundations that still require deployment-specific validation.
+
+## What is simulated or demo-only
+
+The following should be labeled as simulated, deterministic demo behavior, or implementation foundation unless validated in a real pilot environment:
+
+- Browser `/demo` scenarios and demo media outputs.
+- Demo integration payload previews for NAC, SIEM, ITSM, and related action logs.
+- Remediation attempts described in the current demo narrative.
+- Any fallback storyboard media generated when browser capture is unavailable.
+- Local/demo default keys or local-only script configuration.
+- Buyer-safe sample data, seeded posture fixtures, and simulated frontline scenarios.
+
+## What not to claim yet
+
+Do not claim the following until pilot or production validation exists for the target environment:
+
+- Production readiness for a customer deployment.
+- Guaranteed uptime, latency, scale, resilience, or compliance outcomes.
+- Certified regulatory compliance such as HIPAA, SOC 2, ISO 27001, FedRAMP, or PCI.
+- Fully automated remediation with verified post-remediation re-checks.
+- Live customer integrations with a specific IAM, UEM/MDM, DEX, NAC, SIEM, ITSM, or badge system unless that integration has been configured and validated.
+- Replacement of existing identity, endpoint, observability, network, ticketing, or device-management systems.
+- AI-driven autonomous enforcement decisions.
+
+## Replacement boundaries
+
+SignalGrid is positioned as a decision and orchestration layer between authentication, device posture, and enforcement systems. It does **not** replace:
+
+| Existing category | Boundary language |
+| --- | --- |
+| IAM / identity provider | SignalGrid uses identity context; it does not replace identity proofing, authentication, or directory ownership. |
+| UEM / MDM | SignalGrid consumes posture and enrollment signals; it does not manage full device lifecycle, configuration, or app deployment. |
+| DEX / observability | SignalGrid can use operational signals; it does not replace broad employee-experience monitoring or telemetry platforms. |
+| NAC / network enforcement | SignalGrid can request enforcement actions; it does not replace network control planes. |
+| SIEM / SOAR | SignalGrid emits and enriches events; it does not replace security analytics, incident investigation, or enterprise SOAR governance. |
+| ITSM | SignalGrid can create or update workflow records; it does not replace ticketing, change management, or service operations ownership. |
+
+## Safe phrasing
+
+Use language like:
+
+- “SignalGrid sits between authentication and enforcement to make shared-device access decisions based on runtime trust.”
+- “The current MVP demonstrates deterministic access outcomes and auditable decision context.”
+- “Pilot readiness depends on customer-specific integration validation, operational runbooks, and removal of local/demo defaults.”
+- “Remediation is currently shown as a constrained demo narrative unless explicitly implemented and validated in the target environment.”
+
+Avoid language like:
+
+- “Production-ready today.”
+- “Replaces your MDM/IAM/NAC/SIEM/ITSM stack.”
+- “Fully autonomous remediation.”
+- “Compliance guaranteed.”
+- “AI decides who gets access.”

--- a/docs/INTEGRATION_PRIORITIES.md
+++ b/docs/INTEGRATION_PRIORITIES.md
@@ -1,3 +1,51 @@
-# Integration Priorities
+# SignalGrid Integration Priorities
 
-(Your content here)
+SignalGrid integrates by consuming identity/posture/context signals, making a decision, and coordinating downstream actions. Current integration language should distinguish demo simulation from validated customer integrations.
+
+## Current simulated/demo integrations
+
+The current repository can demonstrate integration behavior through deterministic demo flows and local payload previews for:
+
+- Badge/session-start events.
+- Device posture fixtures and telemetry-store reads.
+- NAC-style quarantine/action records.
+- SIEM-style security event records.
+- ITSM-style ticket/action records.
+- Demo media and storyboard outputs.
+
+These are useful for explaining the control loop, but they should not be described as live production integrations unless connected and validated in a target environment.
+
+## First real integration targets
+
+Prioritize the smallest integration set needed to prove a pilot workflow:
+
+1. **Identity / badge source** — confirm who is requesting access and map badge/session context to a user.
+2. **UEM/MDM or endpoint posture source** — provide fresh compliant, non-compliant, or unknown posture signals.
+3. **Audit/event sink** — preserve decision evidence in a customer-approved log destination.
+4. **ITSM workflow** — create reviewable tickets or tasks for denied or remediated sessions.
+5. **NAC or enforcement target** — only after policy, rollback, and safety boundaries are explicit.
+
+## Later integration targets
+
+After the first pilot workflow is stable, consider:
+
+- Additional MDM/UEM providers.
+- Endpoint security and DEX telemetry providers.
+- SIEM/SOAR enrichment and correlation workflows.
+- HRIS or workforce context sources where appropriate and approved.
+- Location/RTLS systems for shared-device return or zone context.
+- Multiple enforcement systems for complex frontline environments.
+
+## Integration safety boundaries
+
+- Do not use production credentials in demos.
+- Do not call real webhooks from browser demo or media capture flows.
+- Require explicit signing secrets and scoped credentials for shared/staging environments.
+- Prefer read-only or audit-only pilot modes before write/enforcement actions.
+- Use least-privilege service accounts and short rollback paths.
+- Keep high-risk actions disabled until policy ownership and approval gates are clear.
+- Record integration actions with enough detail for post-demo or post-pilot review.
+
+## Pilot sequencing recommendation
+
+Start with identity, posture, and audit evidence. Add ticketing next. Add enforcement only when customer stakeholders agree on policy, blast radius, rollback, and success metrics.

--- a/docs/PRODUCT_BOARD.md
+++ b/docs/PRODUCT_BOARD.md
@@ -1,3 +1,47 @@
-# Product Board
+# SignalGrid Product Board
 
-(Your content here)
+This board summarizes current MVP scope, near-term readiness work, pilot-readiness work, and future direction. It is intentionally conservative so the repository remains business-presentable without overstating maturity.
+
+## Current MVP
+
+- Browser `/demo` experience for deterministic buyer-safe walkthroughs.
+- Safe simulated demo API for compliant, non-compliant, and unknown-posture outcomes.
+- Session-start groundwork for signed requests, badge mapping, posture checks, and allow/deny responses.
+- Unknown-posture fail-closed behavior by default.
+- Demo tooling for scripted walkthroughs, validation, and media capture.
+- Production-oriented runbook/container/API foundation that still needs environment-specific validation.
+- Security, disclaimer, and claim-boundary documentation for MVP positioning.
+
+## Near-term demo confidence work
+
+- Keep demo scenarios deterministic and easy to reset.
+- Add scenario-specific verification for allow, deny, and unknown-posture paths.
+- Keep generated demo media current after demo UI/API changes.
+- Maintain clear labels for simulated behavior and sample data.
+- Avoid real webhooks, production secrets, or production data in demo workflows.
+
+## Pilot-readiness work
+
+- Remove or explicitly local-gate remaining default keys/secrets in runtime routes.
+- Validate Docker build/run/healthcheck in a Docker-capable environment.
+- Define target customer workflow, success metrics, owners, rollback path, and support model.
+- Validate customer-selected integrations with scoped credentials and safe test targets.
+- Confirm audit records are complete enough for pilot review.
+- Document operational procedures for deployment, monitoring, incidents, and rollback.
+
+## Future roadmap
+
+- Event-driven decision gateway for runtime access decisions.
+- Constrained remediation playbooks with explicit audit states.
+- Deeper posture integrations with selected UEM/MDM and endpoint telemetry systems.
+- More complete admin workflows for policy configuration, review, and reporting.
+- Expanded integration catalog after first pilot workflows prove repeatable.
+- Optional AI-assisted explanation/classification features under strict guardrails.
+
+## Non-goals
+
+- Replacing IAM, UEM/MDM, DEX, NAC, SIEM, SOAR, or ITSM platforms.
+- Broad autonomous remediation without explicit policy, approval, isolation, and audit controls.
+- Expanding product surface before demo and pilot evidence is stable.
+- Claiming production readiness before deployment validation is complete.
+- Using real customer data in demos or media capture workflows.

--- a/docs/VALUE_MAP.md
+++ b/docs/VALUE_MAP.md
@@ -1,3 +1,57 @@
-# Value Map
+# SignalGrid Value Map
 
-(Your content here)
+SignalGrid connects shared-device access decisions to executive, IT/security, frontline, and audit outcomes. This map keeps the business value concise without expanding beyond current MVP/demo readiness.
+
+## Executive value
+
+| Outcome | SignalGrid contribution |
+| --- | --- |
+| Risk reduction | Makes access decisions explicit instead of assuming shared-device trust. |
+| Operational resilience | Gives frontline workflows a deterministic allow/deny/step-up path when runtime conditions change. |
+| Accountability | Preserves decision context for review, audit, and post-incident learning. |
+| Tool leverage | Uses existing identity, posture, ticketing, security, and enforcement systems instead of replacing them. |
+| Pilot clarity | Defines measurable workflow outcomes before broader rollout. |
+
+## IT and security value
+
+- Connects badge/session context with device posture and policy decisions.
+- Fails closed when posture is unknown by default.
+- Provides a single decision point that can coordinate downstream actions.
+- Makes NAC, SIEM, ITSM, and audit outputs easier to explain in a shared-device workflow.
+- Reduces ambiguity between “authenticated user” and “trusted session.”
+
+## Frontline/shared-device workflow value
+
+- Supports fast, deterministic session decisions for shared and mobile devices.
+- Reduces manual interpretation of device health and access risk.
+- Helps teams understand why access was allowed, denied, or routed to another action.
+- Keeps demos focused on realistic healthcare, logistics, and regulated frontline scenarios.
+- Protects user experience by making policy behavior predictable before pilot rollout.
+
+## Audit and compliance value
+
+SignalGrid is not a compliance certification product, but it can strengthen evidence quality by recording:
+
+- Identity and badge/session context used in the decision.
+- Device posture status and unknown/non-compliant handling.
+- Policy outcome, risk context, and final decision.
+- Downstream demo or integration action records.
+- Timestamps and reason codes useful for review.
+
+## Measurable pilot metrics
+
+Potential pilot success metrics should be agreed with the design partner before deployment. Examples include:
+
+| Metric | Why it matters |
+| --- | --- |
+| Unknown-posture deny rate | Shows where posture telemetry or enrollment is incomplete. |
+| Non-compliant access attempts | Quantifies risky shared-device sessions before access proceeds. |
+| Decision latency | Confirms the workflow remains usable for frontline staff. |
+| Manual escalation volume | Measures whether decision context reduces help desk or security triage burden. |
+| Successful compliant starts | Confirms trusted sessions proceed without unnecessary friction. |
+| Audit record completeness | Verifies that reviewers can reconstruct access decisions. |
+| Integration action accuracy | Confirms downstream NAC/SIEM/ITSM actions match policy intent during pilot scope. |
+
+## Pilot value statement
+
+A good pilot should prove that SignalGrid can make shared-device access decisions clearer, safer, and easier to audit without adding unacceptable frontline friction.


### PR DESCRIPTION
### Summary

- Replaces placeholder business-facing docs with concrete SignalGrid guidance for claim boundaries, value mapping, product scope, integration priorities, and future architecture notes.
- Adds a short README section linking to the business-facing docs so external reviewers can find them without overemphasizing or expanding product claims.
- Keeps all changes documentation-only and conservative around MVP/demo/pilot/production boundaries.

### Files changed

- `README.md`
- `docs/CLAIM_BOUNDARIES.md`
- `docs/VALUE_MAP.md`
- `docs/PRODUCT_BOARD.md`
- `docs/INTEGRATION_PRIORITIES.md`
- `docs/ARCHITECTURE_FUTURE_NOTES.md`

### Validation

- GitHub connector branch created from `main`.
- Placeholder content replaced in the targeted business-facing docs.
- No product logic changed.

Note: The original Codex workspace could not push due missing GitHub credentials, so this PR recreates the same business-facing documentation cleanup directly through the GitHub connector.