### PR TITLE
Add initial SignalGrid visual asset kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SignalGrid
 
+<p align="left">
+  <img src="public/signalgrid-logo.svg" alt="SignalGrid logo" width="360"/>
+</p>
+
+![SignalGrid conceptual runtime decision flow](docs/assets/readme-hero.svg)
+
 **SignalGrid is a Zero Trust orchestration platform for shared and mobile work environments.**
 
 **Mission:** SignalGrid enables secure, contextual, real-time access by continuously evaluating identity, device trust, and operational context.

--- a/docs/VISUAL_ASSETS.md
+++ b/docs/VISUAL_ASSETS.md
@@ -1,0 +1,54 @@
+# SignalGrid Visual Assets
+
+This document tracks the initial SVG brand assets in this repository and how to use them consistently.
+
+> These visuals are **brand assets** and conceptual product framing only. They are not production proof, compliance proof, or deployment claims. Keep all usage aligned to [CLAIM_BOUNDARIES.md](./CLAIM_BOUNDARIES.md).
+
+## Asset inventory
+
+### `public/signalgrid-logo.svg`
+- **Purpose:** Primary SignalGrid logo with mark + wordmark.
+- **Use it for:** README/header placement, docs title areas, basic website masthead usage.
+- **Notes:** Designed around warm charcoal, off-white, and muted teal brand palette.
+
+### `public/signalgrid-logo-mark.svg`
+- **Purpose:** Icon-only monogram mark.
+- **Use it for:** Favicon foundation, avatar/icon usage, compact placements.
+- **Notes:** Constructed to hold up at small sizes and in monochrome contexts.
+
+### `docs/assets/github-social-preview.svg`
+- **Purpose:** Default social preview card for GitHub sharing surfaces.
+- **Use it for:** Open Graph image export source and documentation previews.
+- **Notes:** 1200×630 aspect ratio, restrained enterprise styling, no stock imagery.
+
+### `docs/assets/readme-hero.svg`
+- **Purpose:** Conceptual architecture-style hero visual for repo documentation.
+- **Use it for:** README hero section and explanatory docs.
+- **Notes:** Shows `Identity + Device + Session Context → SignalGrid → Allow / Deny / Step-Up` and explicitly labels itself as conceptual.
+
+### `docs/assets/linkedin-teaser.svg`
+- **Purpose:** Minimal teaser graphic for LinkedIn or similar social posts.
+- **Use it for:** Introductory launch/update posts with restrained positioning.
+- **Notes:** Includes minimal logo treatment and a non-hype one-line message.
+
+## PNG export guidance (when required)
+
+Prefer using source SVG directly whenever possible. If a target platform requires PNG:
+
+1. Export at 1x, 2x, and 3x sizes from the original SVG.
+2. Keep aspect ratio fixed (do not crop logo geometry).
+3. Keep color values unchanged from the SVG source.
+4. Use transparent background only when the destination surface supports it; otherwise preserve warm charcoal background.
+5. Do not add glow, bevel, or neon effects during export.
+
+Suggested CLI example with `rsvg-convert`:
+
+```bash
+rsvg-convert -w 1200 -h 630 docs/assets/github-social-preview.svg -o docs/assets/github-social-preview.png
+```
+
+## Usage reminder
+
+- Keep claims restrained and MVP/demo-safe.
+- Avoid attaching these assets to statements implying certified compliance or guaranteed production outcomes.
+- Keep visual consistency with [BRAND_SYSTEM.md](./BRAND_SYSTEM.md) and [startup/branding/brand.md](../startup/branding/brand.md).

--- a/docs/assets/github-social-preview.svg
+++ b/docs/assets/github-social-preview.svg
@@ -1,0 +1,14 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid GitHub social preview</title>
+  <desc id="desc">SignalGrid social card with restrained enterprise styling and runtime decision layer positioning.</desc>
+  <rect width="1200" height="630" fill="#15181B"/>
+  <rect x="64" y="64" width="1072" height="502" rx="28" fill="#1D2226" stroke="#2A3136" stroke-width="2"/>
+  <circle cx="150" cy="132" r="8" fill="#4F8C87"/>
+  <circle cx="178" cy="132" r="8" fill="#B08B57"/>
+  <circle cx="206" cy="132" r="8" fill="#A15B5B"/>
+  <text x="128" y="275" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="96" font-weight="650" letter-spacing="0.5">SignalGrid</text>
+  <text x="128" y="337" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="500">Runtime Decision Layer Between Authentication and Enforcement</text>
+  <path d="M128 420H520" stroke="#4F8C87" stroke-width="8" stroke-linecap="round"/>
+  <path d="M548 420H856" stroke="#2A3136" stroke-width="8" stroke-linecap="round"/>
+  <path d="M886 420H1072" stroke="#4F8C87" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/docs/assets/linkedin-teaser.svg
+++ b/docs/assets/linkedin-teaser.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="627" viewBox="0 0 1200 627" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid LinkedIn teaser</title>
+  <desc id="desc">Minimal teaser with SignalGrid mark and restrained positioning line.</desc>
+  <rect width="1200" height="627" fill="#15181B"/>
+  <rect x="84" y="84" width="1032" height="459" rx="28" fill="#1D2226" stroke="#2A3136" stroke-width="2"/>
+  <g transform="translate(144 204)">
+    <rect x="0" y="0" width="132" height="132" rx="30" fill="#15181B" stroke="#2A3136" stroke-width="2"/>
+    <path d="M26 36C36 25 50 20 66 20C86 20 102 28 114 42L102 53C93 43 81 37 68 37C56 37 47 41 42 48C37 55 35 61 37 67C39 73 44 77 53 81L81 93C96 100 105 108 108 121C111 134 106 145 96 154C86 163 73 168 58 168C39 168 24 159 14 143L27 133C35 144 46 149 59 149C69 149 77 146 83 140C89 134 91 128 89 122C87 116 82 111 74 107L46 95C31 88 22 79 19 67C16 55 19 45 26 36Z" fill="#F3F1EC"/>
+    <path d="M106 41V57H79V105C79 115 84 120 94 120H105V137H91C73 137 62 127 62 109V57H45V41H62V24H79V41H106Z" fill="#4F8C87"/>
+  </g>
+  <text x="320" y="294" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="72" font-weight="640">SignalGrid</text>
+  <text x="320" y="350" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="500">Runtime decisions between authentication and enforcement.</text>
+</svg>

--- a/docs/assets/readme-hero.svg
+++ b/docs/assets/readme-hero.svg
@@ -1,0 +1,36 @@
+<svg width="1240" height="440" viewBox="0 0 1240 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid README hero diagram</title>
+  <desc id="desc">Conceptual flow: Identity, device, and session context into SignalGrid and decisions allow, deny, or step-up.</desc>
+  <rect width="1240" height="440" rx="20" fill="#15181B"/>
+  <text x="52" y="64" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500">Conceptual diagram (MVP/demo framing, not production proof)</text>
+
+  <rect x="52" y="120" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="166" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Identity Context</text>
+
+  <rect x="52" y="216" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="262" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Device Context</text>
+
+  <rect x="52" y="312" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="358" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Session Context</text>
+
+  <path d="M334 160H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+  <path d="M334 256H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+  <path d="M334 352H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+
+  <rect x="456" y="146" width="312" height="218" rx="20" fill="#1D2226" stroke="#4F8C87" stroke-width="2"/>
+  <text x="520" y="230" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="650">SignalGrid</text>
+  <text x="506" y="268" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="500">Runtime decision layer</text>
+
+  <path d="M780 196H926" stroke="#5E8F73" stroke-width="4" stroke-linecap="round"/>
+  <path d="M780 256H926" stroke="#A15B5B" stroke-width="4" stroke-linecap="round"/>
+  <path d="M780 316H926" stroke="#B08B57" stroke-width="4" stroke-linecap="round"/>
+
+  <rect x="936" y="165" width="252" height="56" rx="12" fill="#1D2226" stroke="#5E8F73"/>
+  <text x="1028" y="200" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Allow</text>
+
+  <rect x="936" y="225" width="252" height="56" rx="12" fill="#1D2226" stroke="#A15B5B"/>
+  <text x="1028" y="260" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Deny</text>
+
+  <rect x="936" y="285" width="252" height="56" rx="12" fill="#1D2226" stroke="#B08B57"/>
+  <text x="1028" y="320" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Step-Up</text>
+</svg>

--- a/public/signalgrid-logo-mark.svg
+++ b/public/signalgrid-logo-mark.svg
@@ -1,0 +1,8 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid logo mark</title>
+  <desc id="desc">Icon-only abstract SignalGrid S/G decision-core monogram for favicon and avatar use.</desc>
+  <rect width="256" height="256" rx="52" fill="#15181B"/>
+  <rect x="29" y="29" width="198" height="198" rx="40" fill="#1D2226" stroke="#2A3136" stroke-width="3"/>
+  <path d="M65 73C79 55 99 46 124 46C154 46 179 58 195 79L173 97C161 81 145 72 125 72C111 72 100 76 92 85C84 94 82 103 85 112C88 121 96 128 109 134L153 151C177 161 191 176 196 198C201 221 194 241 178 256C161 271 139 279 112 279C85 279 62 269 44 250L66 231C79 246 95 253 114 253C129 253 141 248 149 238C157 228 160 218 157 209C154 199 145 191 131 185L86 168C64 160 49 145 44 123C40 104 47 87 65 73Z" fill="#F3F1EC" transform="translate(0 -23)"/>
+  <path d="M186 75V100H145V170C145 184 154 192 170 192H185V217H163C136 217 120 201 120 174V100H95V75H120V49H145V75H186Z" fill="#4F8C87"/>
+</svg>

--- a/public/signalgrid-logo.svg
+++ b/public/signalgrid-logo.svg
@@ -1,0 +1,15 @@
+<svg width="720" height="220" viewBox="0 0 720 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid logo</title>
+  <desc id="desc">Abstract SignalGrid monogram with wordmark in warm charcoal, off-white, and muted teal.</desc>
+  <rect width="720" height="220" rx="24" fill="#15181B"/>
+  <g transform="translate(42 36)">
+    <rect x="0" y="0" width="148" height="148" rx="30" fill="#1D2226" stroke="#2A3136" stroke-width="2"/>
+    <path d="M33 40C43 28 57 22 74 22C95 22 111 30 123 45L109 57C100 45 88 39 74 39C62 39 53 43 47 50C41 57 39 64 41 70C43 76 48 81 57 85L89 98C105 105 115 115 118 129C121 143 116 156 105 166C95 176 81 181 64 181C44 181 27 172 15 155L30 143C39 156 51 162 65 162C76 162 84 159 91 152C98 146 100 139 98 133C96 126 90 121 81 117L49 104C33 97 23 86 20 72C18 60 22 49 33 40Z" fill="#F3F1EC"/>
+    <path d="M112 43V61H82V113C82 124 88 130 100 130H111V148H95C75 148 64 137 64 117V61H45V43H64V24H82V43H112Z" fill="#4F8C87"/>
+  </g>
+  <g transform="translate(230 76)">
+    <text x="0" y="56" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="68" font-weight="600" letter-spacing="0.8">SignalGrid</text>
+    <text x="2" y="92" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="500" letter-spacing="0.4">Runtime Decision Layer</text>
+  </g>
+  <line x1="216" y1="50" x2="216" y2="170" stroke="#2A3136" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Provide an initial set of scalable SVG brand assets (primary logo, compact mark, README hero, social preview, LinkedIn teaser) to align repo visuals with `docs/BRAND_SYSTEM.md` and `startup/branding/brand.md`.
- Supply a lightweight usage guide and export guidance while reinforcing claim boundaries so visuals are used as conceptual/demo assets rather than production claims.

### Description
- Add `public/signalgrid-logo.svg` as the primary mark + wordmark using warm charcoal, off-white, and muted teal and designed to scale to favicon sizes. 
- Add `public/signalgrid-logo-mark.svg` as an icon-only monogram suitable for favicons/avatars and small placements. 
- Add `docs/assets/github-social-preview.svg`, `docs/assets/readme-hero.svg`, and `docs/assets/linkedin-teaser.svg` as restrained SVGs for social/README/teaser usage (1200×630 social preview included). 
- Add `docs/VISUAL_ASSETS.md` documenting asset purposes, where to use them, PNG export guidance, and a reminder to follow `docs/CLAIM_BOUNDARIES.md`, and lightly update `README.md` to include the new logo and hero. 

### Testing
- Ran `git diff --check` and it completed without failures. 
- Ran `npm run lint` (ESLint) and it completed successfully with a non-blocking npm environment warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7ac0a904832eb34d64ddbb4e691f)