### PR TITLE
Add README hero SVG and redesign homepage layout/styles

### DIFF
--- a/public/readme-hero.svg
+++ b/public/readme-hero.svg
@@ -1,0 +1,36 @@
+<svg width="1240" height="440" viewBox="0 0 1240 440" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid README hero diagram</title>
+  <desc id="desc">Conceptual flow: Identity, device, and session context into SignalGrid and decisions allow, deny, or step-up.</desc>
+  <rect width="1240" height="440" rx="20" fill="#15181B"/>
+  <text x="52" y="64" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500">Conceptual diagram (MVP/demo framing, not production proof)</text>
+
+  <rect x="52" y="120" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="166" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Identity Context</text>
+
+  <rect x="52" y="216" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="262" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Device Context</text>
+
+  <rect x="52" y="312" width="270" height="78" rx="14" fill="#1D2226" stroke="#2A3136"/>
+  <text x="76" y="358" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="550">Session Context</text>
+
+  <path d="M334 160H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+  <path d="M334 256H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+  <path d="M334 352H452" stroke="#4F8C87" stroke-width="4" stroke-linecap="round"/>
+
+  <rect x="456" y="146" width="312" height="218" rx="20" fill="#1D2226" stroke="#4F8C87" stroke-width="2"/>
+  <text x="520" y="230" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="650">SignalGrid</text>
+  <text x="506" y="268" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="500">Runtime decision layer</text>
+
+  <path d="M780 196H926" stroke="#5E8F73" stroke-width="4" stroke-linecap="round"/>
+  <path d="M780 256H926" stroke="#A15B5B" stroke-width="4" stroke-linecap="round"/>
+  <path d="M780 316H926" stroke="#B08B57" stroke-width="4" stroke-linecap="round"/>
+
+  <rect x="936" y="165" width="252" height="56" rx="12" fill="#1D2226" stroke="#5E8F73"/>
+  <text x="1028" y="200" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Allow</text>
+
+  <rect x="936" y="225" width="252" height="56" rx="12" fill="#1D2226" stroke="#A15B5B"/>
+  <text x="1028" y="260" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Deny</text>
+
+  <rect x="936" y="285" width="252" height="56" rx="12" fill="#1D2226" stroke="#B08B57"/>
+  <text x="1028" y="320" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="600">Step-Up</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,88 +1,137 @@
+const outcomes = [
+  {
+    title: 'Allow',
+    color: 'text-[#5E8F73]',
+    body: 'Trusted identity, healthy posture, and expected session context continue with minimal friction.',
+  },
+  {
+    title: 'Step-Up',
+    color: 'text-[#B08B57]',
+    body: 'Elevated risk triggers additional verification and operator-visible context before access proceeds.',
+  },
+  {
+    title: 'Deny',
+    color: 'text-[#A15B5B]',
+    body: 'Unknown or high-risk runtime states fail closed and return auditable reasoning for follow-up.',
+  },
+];
+
 export default function HomePage() {
   return (
-    <main className="min-h-screen bg-neutral-950 px-6 py-16 text-neutral-100">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
-        <header className="space-y-5 border-b border-neutral-800 pb-10">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-neutral-400">SignalGrid</p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
-            Fix Risk Before It Breaks Access
-          </h1>
-          <p className="max-w-3xl text-lg text-neutral-300">
-            SignalGrid is a shared-device access and runtime decision platform for frontline environments that resolves
-            identity, device, and session risk before access breaks.
-          </p>
+    <main className="min-h-screen bg-[#15181B] px-6 py-12 text-[#F3F1EC] md:py-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16">
+        <header className="rounded-3xl border border-[#2A3136] bg-[#1D2226] p-8 md:p-12">
+          <div className="mb-8 flex items-center gap-4">
+            <img src="/signalgrid-logo-mark.svg" alt="SignalGrid mark" className="h-11 w-11" />
+            <img src="/signalgrid-logo.svg" alt="SignalGrid" className="h-7 w-auto" />
+          </div>
+
+          <div className="grid gap-10 lg:grid-cols-[1.1fr,0.9fr] lg:items-end">
+            <div className="space-y-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#D8D4CC]">
+                Runtime decision layer for Zero Trust orchestration
+              </p>
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight md:text-5xl">
+                Access decisions should stay correct after authentication.
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-[#D8D4CC] md:text-lg">
+                SignalGrid helps shared-device and frontline teams evaluate identity, device posture, and session
+                context in real time so access outcomes reflect runtime truth, not stale checks.
+              </p>
+              <a
+                href="mailto:sales@signalgrid.io?subject=SignalGrid%20Early%20Access%20Request"
+                className="inline-flex rounded-lg border border-[#4F8C87] bg-[#4F8C87]/10 px-5 py-3 text-sm font-semibold text-[#F3F1EC] transition hover:border-[#6FA7A1] hover:bg-[#6FA7A1]/15"
+              >
+                Request early access
+              </a>
+            </div>
+            <img
+              src="/readme-hero.svg"
+              alt="SignalGrid decision flow illustration"
+              className="w-full rounded-2xl border border-[#2A3136] bg-[#15181B] p-3"
+            />
+          </div>
         </header>
 
-        <section className="space-y-8">
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Where SignalGrid fits</h2>
-            <p className="mt-3 text-neutral-200">
-              Identity systems authenticate. Access systems enforce. SignalGrid decides what happens in between.
-            </p>
-          </article>
-
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Why now</h2>
-            <p className="mt-3 text-neutral-200">
-              Modern enterprise environments can verify identity, enforce policy, and visualize issues, but they still
-              leave a runtime decision gap. When risk is detected, most systems either block the user or rely on manual
-              remediation. SignalGrid launches with high-friction frontline shared-device workflows and later expands
-              into additional industries where access continuity is mission-critical.
-            </p>
-          </article>
-
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">
-              Beyond traditional Zero Trust
-            </h2>
-            <p className="mt-3 text-neutral-200">
-              Traditional Zero Trust architectures verify identity and enforce policy at the point of access.
-            </p>
-            <p className="mt-4 text-neutral-200">But real-world conditions change.</p>
-            <p className="mt-4 text-neutral-200">Devices fail. Networks degrade. Signals become stale.</p>
-            <p className="mt-4 text-neutral-200">
-              SignalGrid extends Zero Trust into runtime decisioning—ensuring access decisions remain correct even
-              after they are made.
-            </p>
-          </article>
-
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Runtime truth</h2>
-            <p className="mt-3 text-neutral-200">
-              Even when authentication succeeds and compliance looks healthy, runtime conditions can still silently
-              fail. We have seen operating environments appear healthy while losing the ability to establish new TCP
-              connections after prolonged uptime, forcing manual recovery and disruption. SignalGrid helps ensure
-              access decisions reflect runtime truth, not stale or incomplete signals.
-            </p>
-          </article>
-
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">What SignalGrid does</h2>
-            <p className="mt-3 text-neutral-200">
-              SignalGrid connects identity, device posture, and runtime risk signals, determines whether remediation
-              can be attempted, re-evaluates trust after response, and returns a final allow or deny decision with
-              audit context.
-            </p>
-          </article>
-
-          <article className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-6">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-400">Differentiation</h2>
-            <p className="mt-3 text-neutral-200">
-              UEM tools show what&apos;s configured. DEX tools show what&apos;s failing. SignalGrid decides what happens
-              next and returns a final access decision before workflow disruption.
-            </p>
-          </article>
-
+        <section className="grid gap-6 rounded-3xl border border-[#2A3136] bg-[#1D2226]/70 p-8 md:grid-cols-3">
+          <h2 className="text-2xl font-semibold md:col-span-3">The runtime access gap</h2>
+          <p className="text-[#D8D4CC]">
+            Identity systems authenticate. Enforcement systems act. Critical frontline sessions still break when runtime
+            conditions change between those points.
+          </p>
+          <p className="text-[#D8D4CC]">
+            SignalGrid orchestrates trust signals across identity, device posture, and session context before
+            disruptions cascade into downtime.
+          </p>
+          <p className="text-[#D8D4CC]">
+            The current release candidate is an MVP/demo path built to validate deterministic runtime outcomes and
+            auditable decision context.
+          </p>
         </section>
 
-        <section className="flex flex-col items-start gap-4 border-t border-neutral-800 pt-10">
+        <section className="space-y-5">
+          <h2 className="text-2xl font-semibold">How SignalGrid works</h2>
+          <div className="grid gap-4 md:grid-cols-4">
+            {[
+              'Ingest identity and posture signals',
+              'Evaluate runtime session context',
+              'Apply policy logic and orchestration paths',
+              'Return an auditable allow, step-up, or deny outcome',
+            ].map((step, idx) => (
+              <article key={step} className="rounded-2xl border border-[#2A3136] bg-[#1D2226] p-5">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[#4F8C87]">Step {idx + 1}</p>
+                <p className="text-sm leading-6 text-[#D8D4CC]">{step}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-5">
+          <h2 className="text-2xl font-semibold">Demo outcomes: Allow / Deny / Step-Up</h2>
+          <div className="grid gap-4 md:grid-cols-3">
+            {outcomes.map((outcome) => (
+              <article key={outcome.title} className="rounded-2xl border border-[#2A3136] bg-[#1D2226] p-6">
+                <h3 className={`text-xl font-semibold ${outcome.color}`}>{outcome.title}</h3>
+                <p className="mt-3 text-sm leading-6 text-[#D8D4CC]">{outcome.body}</p>
+              </article>
+            ))}
+          </div>
+          <p className="text-sm text-[#D8D4CC]">
+            Outcomes shown in the current environment are deterministic MVP/demo behaviors and should be validated in
+            pilot deployments before production claims.
+          </p>
+        </section>
+
+        <section className="rounded-3xl border border-[#2A3136] bg-[#1D2226]/70 p-8">
+          <h2 className="text-2xl font-semibold">Who it is for</h2>
+          <ul className="mt-5 grid gap-4 text-[#D8D4CC] md:grid-cols-2">
+            <li className="rounded-xl border border-[#2A3136] bg-[#15181B]/50 p-4">
+              Security and identity teams supporting shared or mobile frontline devices.
+            </li>
+            <li className="rounded-xl border border-[#2A3136] bg-[#15181B]/50 p-4">
+              Operations teams that need runtime access continuity with clear, auditable decisions.
+            </li>
+            <li className="rounded-xl border border-[#2A3136] bg-[#15181B]/50 p-4">
+              Organizations aligning Zero Trust programs with session-level orchestration, not static checks only.
+            </li>
+            <li className="rounded-xl border border-[#2A3136] bg-[#15181B]/50 p-4">
+              Design partners exploring early-stage posture-aware access controls in constrained environments.
+            </li>
+          </ul>
+        </section>
+
+        <section className="rounded-3xl border border-[#4F8C87]/60 bg-[#4F8C87]/10 p-8 text-center">
+          <h2 className="text-2xl font-semibold">Early access</h2>
+          <p className="mx-auto mt-3 max-w-2xl text-[#D8D4CC]">
+            SignalGrid is currently in controlled demo and design-partner validation. Request early access to review
+            roadmap, constraints, and pilot-fit criteria.
+          </p>
           <a
             href="mailto:sales@signalgrid.io?subject=SignalGrid%20Early%20Access%20Request"
-            className="rounded-lg border border-cyan-400/60 bg-cyan-500/10 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-cyan-200"
+            className="mt-6 inline-flex rounded-lg border border-[#4F8C87] bg-[#15181B] px-6 py-3 text-sm font-semibold text-[#F3F1EC] hover:border-[#6FA7A1]"
           >
-            Request Early Access
+            Request early access
           </a>
-          <p className="text-sm text-neutral-400">For early design-partner conversations and pilot interest.</p>
         </section>
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 const outcomes = [
   {
     title: 'Allow',
@@ -22,8 +24,8 @@ export default function HomePage() {
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-16">
         <header className="rounded-3xl border border-[#2A3136] bg-[#1D2226] p-8 md:p-12">
           <div className="mb-8 flex items-center gap-4">
-            <img src="/signalgrid-logo-mark.svg" alt="SignalGrid mark" className="h-11 w-11" />
-            <img src="/signalgrid-logo.svg" alt="SignalGrid" className="h-7 w-auto" />
+            <Image src="/signalgrid-logo-mark.svg" alt="SignalGrid mark" width={44} height={44} className="h-11 w-11" priority />
+            <Image src="/signalgrid-logo.svg" alt="SignalGrid" width={180} height={28} className="h-7 w-auto" priority />
           </div>
 
           <div className="grid gap-10 lg:grid-cols-[1.1fr,0.9fr] lg:items-end">
@@ -45,10 +47,13 @@ export default function HomePage() {
                 Request early access
               </a>
             </div>
-            <img
+            <Image
               src="/readme-hero.svg"
               alt="SignalGrid decision flow illustration"
+              width={1240}
+              height={440}
               className="w-full rounded-2xl border border-[#2A3136] bg-[#15181B] p-3"
+              priority
             />
           </div>
         </header>


### PR DESCRIPTION
### Motivation
- Introduce a dedicated hero illustration and refresh the landing page to better explain SignalGrid's runtime decisioning and demo outcomes. 
- Improve visual hierarchy and copy to support early-access conversion and clearer demo documentation.

### Description
- Add a new hero illustration at `public/readme-hero.svg` that visualizes identity, device, and session inputs flowing into SignalGrid with Allow/Step-Up/Deny outcomes.  
- Replace and rewrite `src/app/page.tsx` to a redesigned landing layout with updated colors, rounded containers, and a header that uses the new hero and logo assets.  
- Add an `outcomes` array and map-driven UI for demo outcomes and a mapped step sequence for the feature flow, consolidating repeated markup into mapped lists.  
- Update CTA copy and styles for the early-access flow and reorganize page sections (runtime access gap, how it works, demo outcomes, who it is for).

### Testing
- No automated unit tests were added or modified in this change.  
- Verified the application compiles and pages render locally in a dev build (TypeScript/JSX compilation succeeded).  
- Manually inspected the homepage in the dev server to confirm the hero image, outcomes, and CTA render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8666a524832e9bab7d959dc91611)