### PR TITLE
Add SignalGrid runtime decision architecture marketing infographic

### DIFF
--- a/docs/VISUAL_ASSETS.md
+++ b/docs/VISUAL_ASSETS.md
@@ -31,6 +31,12 @@ This document tracks the initial SVG brand assets in this repository and how to 
 - **Use it for:** Introductory launch/update posts with restrained positioning.
 - **Notes:** Includes minimal logo treatment and a non-hype one-line message.
 
+
+### `docs/assets/signalgrid-runtime-architecture.svg`
+- **Purpose:** Primary marketing architecture poster for SignalGrid runtime decision positioning.
+- **Use it for:** README/website architecture section, investor decks, discovery calls, and LinkedIn thought-leadership visuals.
+- **Notes:** Conceptual diagram emphasizing runtime inputs, SignalGrid decision logic, deterministic outcomes, and integration boundaries. Keep copy aligned to claim boundaries and avoid implying validated production integrations.
+
 ## PNG export guidance (when required)
 
 Prefer using source SVG directly whenever possible. If a target platform requires PNG:

--- a/docs/assets/signalgrid-runtime-architecture.svg
+++ b/docs/assets/signalgrid-runtime-architecture.svg
@@ -1,0 +1,141 @@
+<svg width="1600" height="980" viewBox="0 0 1600 980" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">SignalGrid Runtime Decision Layer architecture infographic</title>
+  <desc id="desc">Conceptual enterprise architecture view showing runtime inputs, SignalGrid decision layer, outcomes, and integration flow boundaries.</desc>
+
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="980" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#15181B"/>
+      <stop offset="1" stop-color="#1D2226"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="980" fill="url(#bg)"/>
+
+  <!-- minimal grid -->
+  <g opacity="0.24" stroke="#2A3136" stroke-width="1">
+    <line x1="80" y1="120" x2="1520" y2="120"/>
+    <line x1="80" y1="260" x2="1520" y2="260"/>
+    <line x1="80" y1="400" x2="1520" y2="400"/>
+    <line x1="80" y1="540" x2="1520" y2="540"/>
+    <line x1="80" y1="680" x2="1520" y2="680"/>
+    <line x1="80" y1="820" x2="1520" y2="820"/>
+    <line x1="280" y1="80" x2="280" y2="900"/>
+    <line x1="560" y1="80" x2="560" y2="900"/>
+    <line x1="840" y1="80" x2="840" y2="900"/>
+    <line x1="1120" y1="80" x2="1120" y2="900"/>
+    <line x1="1400" y1="80" x2="1400" y2="900"/>
+  </g>
+
+  <text x="80" y="74" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="46" font-weight="700">SignalGrid Runtime Decision Layer</text>
+  <text x="80" y="108" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500">Zero Trust orchestration for shared and mobile frontline environments.</text>
+
+  <text x="100" y="170" fill="#6FA7A1" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">Runtime Inputs</text>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="90" y="188" width="350" height="120" rx="14" fill="#1D2226" stroke="#2A3136"/>
+    <text x="110" y="220" fill="#F3F1EC" font-size="18" font-weight="600">Identity context</text>
+    <text x="110" y="246" fill="#D8D4CC" font-size="15">• user   • role   • authentication state</text>
+    <text x="110" y="270" fill="#D8D4CC" font-size="15">• badge/session event</text>
+
+    <rect x="90" y="322" width="350" height="120" rx="14" fill="#1D2226" stroke="#2A3136"/>
+    <text x="110" y="354" fill="#F3F1EC" font-size="18" font-weight="600">Device posture</text>
+    <text x="110" y="380" fill="#D8D4CC" font-size="15">• managed state   • compliance</text>
+    <text x="110" y="404" fill="#D8D4CC" font-size="15">• telemetry freshness   • risk indicators</text>
+
+    <rect x="90" y="456" width="350" height="120" rx="14" fill="#1D2226" stroke="#2A3136"/>
+    <text x="110" y="488" fill="#F3F1EC" font-size="18" font-weight="600">Session context</text>
+    <text x="110" y="514" fill="#D8D4CC" font-size="15">• location   • workflow   • device assignment</text>
+    <text x="110" y="538" fill="#D8D4CC" font-size="15">• shift/use case</text>
+
+    <rect x="90" y="590" width="350" height="120" rx="14" fill="#1D2226" stroke="#2A3136"/>
+    <text x="110" y="622" fill="#F3F1EC" font-size="18" font-weight="600">Operational signals</text>
+    <text x="110" y="648" fill="#D8D4CC" font-size="15">• policy   • service state</text>
+    <text x="110" y="672" fill="#D8D4CC" font-size="15">• ticket/security events   • environment context</text>
+  </g>
+
+  <g>
+    <rect x="500" y="220" width="560" height="430" rx="20" fill="#20272C" stroke="#4F8C87" stroke-width="2"/>
+    <text x="780" y="280" text-anchor="middle" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="700">SignalGrid</text>
+    <text x="780" y="312" text-anchor="middle" fill="#6FA7A1" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="500">Runtime truth before access outcome.</text>
+
+    <rect x="545" y="338" width="470" height="64" rx="12" fill="#1A1F23" stroke="#2A3136"/>
+    <text x="570" y="378" fill="#F3F1EC" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">Session decision engine</text>
+
+    <rect x="545" y="414" width="470" height="52" rx="12" fill="#1A1F23" stroke="#2A3136"/>
+    <text x="570" y="447" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18">Policy + context evaluation</text>
+
+    <rect x="545" y="478" width="470" height="52" rx="12" fill="#1A1F23" stroke="#2A3136"/>
+    <text x="570" y="511" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18">Posture verification</text>
+
+    <rect x="545" y="542" width="470" height="52" rx="12" fill="#1A1F23" stroke="#2A3136"/>
+    <text x="570" y="575" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18">Remediation attempt / re-check</text>
+
+    <rect x="545" y="606" width="470" height="52" rx="12" fill="#1A1F23" stroke="#2A3136"/>
+    <text x="570" y="639" fill="#D8D4CC" font-family="Inter, Arial, sans-serif" font-size="18">Audit + evidence record</text>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <text x="1140" y="170" fill="#6FA7A1" font-size="20" font-weight="600">Outcomes</text>
+    <rect x="1120" y="188" width="390" height="68" rx="12" fill="#22292E" stroke="#5E8F73"/>
+    <text x="1150" y="231" fill="#F3F1EC" font-size="24" font-weight="600">Allow</text>
+
+    <rect x="1120" y="270" width="390" height="68" rx="12" fill="#22292E" stroke="#B08B57"/>
+    <text x="1150" y="313" fill="#F3F1EC" font-size="24" font-weight="600">Step-Up / Review</text>
+
+    <rect x="1120" y="352" width="390" height="68" rx="12" fill="#22292E" stroke="#A15B5B"/>
+    <text x="1150" y="395" fill="#F3F1EC" font-size="24" font-weight="600">Deny</text>
+
+    <rect x="1120" y="434" width="390" height="68" rx="12" fill="#22292E" stroke="#6FA7A1"/>
+    <text x="1150" y="477" fill="#F3F1EC" font-size="24" font-weight="600">Remediate</text>
+
+    <rect x="1120" y="516" width="390" height="68" rx="12" fill="#22292E" stroke="#D8D4CC"/>
+    <text x="1150" y="559" fill="#F3F1EC" font-size="24" font-weight="600">Record / Audit</text>
+  </g>
+
+  <g stroke="#4F8C87" stroke-width="2.5" marker-end="url(#arrow)">
+    <line x1="442" y1="450" x2="490" y2="450"/>
+    <line x1="1062" y1="450" x2="1112" y2="450"/>
+  </g>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0,0 10,4 0,8" fill="#4F8C87"/>
+    </marker>
+  </defs>
+
+  <text x="80" y="760" fill="#6FA7A1" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="600">From static access policy to runtime outcome control</text>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="80" y="780" width="300" height="120" rx="12" fill="#1D2226" stroke="#2A3136"/>
+    <text x="100" y="818" fill="#F3F1EC" font-size="20" font-weight="600">IAM / IdP</text>
+    <text x="100" y="846" fill="#D8D4CC" font-size="16">Authenticate identity</text>
+
+    <rect x="420" y="780" width="300" height="120" rx="12" fill="#1D2226" stroke="#4F8C87"/>
+    <text x="440" y="818" fill="#F3F1EC" font-size="20" font-weight="600">SignalGrid</text>
+    <text x="440" y="846" fill="#D8D4CC" font-size="16">Decide based on runtime truth</text>
+
+    <rect x="760" y="780" width="320" height="120" rx="12" fill="#1D2226" stroke="#2A3136"/>
+    <text x="780" y="818" fill="#F3F1EC" font-size="20" font-weight="600">Enforcement systems</text>
+    <text x="780" y="846" fill="#D8D4CC" font-size="16">Apply access outcome</text>
+
+    <rect x="1120" y="780" width="320" height="120" rx="12" fill="#1D2226" stroke="#2A3136"/>
+    <text x="1140" y="818" fill="#F3F1EC" font-size="20" font-weight="600">Audit / Operations</text>
+    <text x="1140" y="846" fill="#D8D4CC" font-size="16">Preserve evidence and review</text>
+
+    <line x1="380" y1="840" x2="418" y2="840" stroke="#4F8C87" stroke-width="2.5" marker-end="url(#arrow)"/>
+    <line x1="722" y1="840" x2="758" y2="840" stroke="#4F8C87" stroke-width="2.5" marker-end="url(#arrow)"/>
+    <line x1="1082" y1="840" x2="1118" y2="840" stroke="#4F8C87" stroke-width="2.5" marker-end="url(#arrow)"/>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="1120" y="604" width="390" height="152" rx="12" fill="#1D2226" stroke="#2A3136"/>
+    <text x="1140" y="634" fill="#6FA7A1" font-size="18" font-weight="600">Strategy principles</text>
+    <text x="1140" y="660" fill="#D8D4CC" font-size="15">• Fail closed when trust is unknown</text>
+    <text x="1140" y="682" fill="#D8D4CC" font-size="15">• Use existing IAM / MDM / SIEM / ITSM</text>
+    <text x="1140" y="704" fill="#D8D4CC" font-size="15">• Do not replace systems of record</text>
+    <text x="1140" y="726" fill="#D8D4CC" font-size="15">• Keep decisions deterministic and auditable</text>
+    <text x="1140" y="748" fill="#D8D4CC" font-size="15">• Start narrow, validate with pilots</text>
+  </g>
+
+  <text x="80" y="948" fill="#D8D4CC" opacity="0.9" font-family="Inter, Arial, sans-serif" font-size="14">Conceptual architecture for MVP/demo and pilot planning. Real integrations require scoped validation.</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a single, premium, marketing-ready SVG poster that explains SignalGrid’s runtime decision layer and where it sits in an enterprise orchestration flow.
- Replace a generic diagram with a cleaner, brand-aligned asset that communicates runtime inputs → decision → outcomes while staying within MVP/demo claim boundaries.

### Description
- Add `docs/assets/signalgrid-runtime-architecture.svg` as an SVG-only marketing architecture poster containing the requested header, left-column runtime input cards (Identity, Device posture, Session context, Operational signals), central `SignalGrid` decision block with internal components, right-column outcome cards (Allow / Step-Up / Deny / Remediate / Record), bottom orchestration flow, strategy principles panel, and MVP-safe footer disclaimer.
- Apply brand-aligned styling using the repo palette (warm charcoal background, off-white typography, muted teal accent, and restrained state colors) and a minimal architectural grid for presentation-scale readability.
- Update `docs/VISUAL_ASSETS.md` to document the new asset with `purpose`, `recommended use`, `export guidance`, and a `claim-boundary` reminder.
- Keep the change SVG-only with no binary assets added and preserve copy consistent with `docs/CLAIM_BOUNDARIES.md` and `docs/BRAND_SYSTEM.md` guidance.

### Testing
- Ran `git diff --check` which returned clean results and reported no whitespace/patch issues.
- Ran `npm run lint` (ESLint) which completed successfully for the modified files.
- No automated build (`npm run build`) or GitHub-hosted checks were run in this environment, so merge gating by CI should still be validated on GitHub before landing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd133366c832e80da5180efcb7328)