### PR TITLE
Add SignalGrid launch outreach package documentation

### DIFF
--- a/docs/LAUNCH_OUTREACH_PACKAGE.md
+++ b/docs/LAUNCH_OUTREACH_PACKAGE.md
@@ -3,8 +3,19 @@
 ## Purpose
 This package is for early design-partner outreach using the current landing page, demo, and architecture visual. It is designed to start high-quality conversations and secure pilot discovery calls.
 
+## Link placeholders to complete before sending
+- Demo URL: `{{DEMO_URL}}`
+- Scenario verification URL: `{{SCENARIO_VERIFICATION_URL}}`
+- Architecture visual URL: `{{ARCHITECTURE_VISUAL_URL}}`
+- Pilot outline URL: `{{PILOT_OUTLINE_URL}}`
+
+## Internal mapping note
+For local/internal demos, these placeholders usually map to:
+- `{{DEMO_URL}}` → `/demo`
+- `{{SCENARIO_VERIFICATION_URL}}` → `/api/demo/verify?scenario=all`
+- `{{ARCHITECTURE_VISUAL_URL}}` → `docs/assets/signalgrid-runtime-architecture.svg`
+
 ## Guardrails
-- Use fully qualified links in external outreach; replace `{{SignalGridBaseUrl}}` with your public HTTPS host (example: `https://demo.signalgrid.example`).
 - Do **not** position SignalGrid as production-ready.
 - Do **not** imply compliance certification or legal guarantees.
 - Do **not** claim replacement of existing IAM, UEM, endpoint security, or broader enterprise security programs.
@@ -18,8 +29,8 @@ SignalGrid is a runtime decision layer for shared-device and mobile frontline en
 The goal is simple:
 help teams make clearer access decisions using identity, device posture, and session context before workflows break.
 What I can show today:
-- a live `{{SignalGridBaseUrl}}/demo` flow
-- scenario verification through `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all`
+- a live `{{DEMO_URL}}` flow
+- scenario verification through `{{SCENARIO_VERIFICATION_URL}}`
 - an architecture view showing where SignalGrid fits between authentication and enforcement
 This is early and intentionally scoped. Not a production rollout pitch.
 If you work in endpoint, mobility, IAM, UEM, frontline IT, or security architecture and this problem sounds familiar, I’d value 15 minutes of candid feedback.
@@ -50,9 +61,9 @@ I’m reaching out because your team’s work in {{Company/Area}} seems closely 
 I’m currently running a small design-partner motion for **SignalGrid**. This is not a production rollout pitch — it’s a structured feedback loop with endpoint, mobility, IAM, UEM, frontline IT, and security architecture leaders.
 
 What we can share today:
-- live product flow at `{{SignalGridBaseUrl}}/demo`
-- verification endpoint: `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all`
-- architecture explainer: `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg`
+- live product flow at `{{DEMO_URL}}`
+- verification endpoint: `{{SCENARIO_VERIFICATION_URL}}`
+- architecture explainer: `{{ARCHITECTURE_VISUAL_URL}}`
 
 If useful, I’d love a 15-minute discovery call to understand your current access-decision workflow and see if a short pilot is worth scoping.
 
@@ -98,9 +109,9 @@ Ask:
 4. What would make a pilot worthwhile in 30–45 days?
 
 ## 6:00–10:00 — Show + React
-- Show `{{SignalGridBaseUrl}}/demo` flow.
-- Reference `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all` to demonstrate scenario coverage.
-- Use `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg` to explain where SignalGrid sits between authentication and enforcement.
+- Show `{{DEMO_URL}}` flow.
+- Reference `{{SCENARIO_VERIFICATION_URL}}` to demonstrate scenario coverage.
+- Use `{{ARCHITECTURE_VISUAL_URL}}` to explain where SignalGrid sits between authentication and enforcement.
 
 Prompt reactions:
 - “What feels realistic vs. hand-wavy?”
@@ -157,11 +168,11 @@ Evaluate whether SignalGrid improves clarity and speed of access outcomes in a l
 ## 7) Short Demo Walkthrough Script
 “Thanks for taking a look — I’ll keep this brief and concrete.
 
-First, I’ll open `{{SignalGridBaseUrl}}/demo` and walk through the current runtime decision flow end-to-end for shared-device and mobile frontline scenarios. As we do this, note where your endpoint, mobility/UEM, IAM, and frontline IT ownership boundaries show up.
+First, I’ll open `{{DEMO_URL}}` and walk through the current runtime decision flow end-to-end for shared-device and mobile frontline scenarios. As we do this, note where your endpoint, mobility/UEM, IAM, and frontline IT ownership boundaries show up.
 
-Second, I’ll reference `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all` to show that each demo scenario path is wired and verifiable in the current build.
+Second, I’ll reference `{{SCENARIO_VERIFICATION_URL}}` to show that each demo scenario path is wired and verifiable in the current build.
 
-Third, I’ll pull up `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg` to anchor where SignalGrid fits between authentication and enforcement.
+Third, I’ll pull up `{{ARCHITECTURE_VISUAL_URL}}` to anchor where SignalGrid fits between authentication and enforcement.
 
 Important context: this is design-partner stage. We’re not positioning this as production-ready, and remediation actions are represented as simulated talk-track unless validated in your environment.
 

--- a/docs/LAUNCH_OUTREACH_PACKAGE.md
+++ b/docs/LAUNCH_OUTREACH_PACKAGE.md
@@ -4,6 +4,7 @@
 This package is for early design-partner outreach using the current landing page, demo, and architecture visual. It is designed to start high-quality conversations and secure pilot discovery calls.
 
 ## Guardrails
+- Use fully qualified links in external outreach; replace `{{SignalGridBaseUrl}}` with your public HTTPS host (example: `https://demo.signalgrid.example`).
 - Do **not** position SignalGrid as production-ready.
 - Do **not** imply compliance certification or legal guarantees.
 - Do **not** claim replacement of existing IAM, UEM, endpoint security, or broader enterprise security programs.
@@ -17,8 +18,8 @@ SignalGrid is a runtime decision layer for shared-device and mobile frontline en
 The goal is simple:
 help teams make clearer access decisions using identity, device posture, and session context before workflows break.
 What I can show today:
-- a live `/demo` flow
-- scenario verification through `/api/demo/verify?scenario=all`
+- a live `{{SignalGridBaseUrl}}/demo` flow
+- scenario verification through `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all`
 - an architecture view showing where SignalGrid fits between authentication and enforcement
 This is early and intentionally scoped. Not a production rollout pitch.
 If you work in endpoint, mobility, IAM, UEM, frontline IT, or security architecture and this problem sounds familiar, I’d value 15 minutes of candid feedback.
@@ -49,9 +50,9 @@ I’m reaching out because your team’s work in {{Company/Area}} seems closely 
 I’m currently running a small design-partner motion for **SignalGrid**. This is not a production rollout pitch — it’s a structured feedback loop with endpoint, mobility, IAM, UEM, frontline IT, and security architecture leaders.
 
 What we can share today:
-- live product flow at `/demo`
-- verification endpoint: `/api/demo/verify?scenario=all`
-- architecture explainer: `docs/assets/signalgrid-runtime-architecture.svg`
+- live product flow at `{{SignalGridBaseUrl}}/demo`
+- verification endpoint: `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all`
+- architecture explainer: `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg`
 
 If useful, I’d love a 15-minute discovery call to understand your current access-decision workflow and see if a short pilot is worth scoping.
 
@@ -97,9 +98,9 @@ Ask:
 4. What would make a pilot worthwhile in 30–45 days?
 
 ## 6:00–10:00 — Show + React
-- Show `/demo` flow.
-- Reference `/api/demo/verify?scenario=all` to demonstrate scenario coverage.
-- Use `docs/assets/signalgrid-runtime-architecture.svg` to explain where SignalGrid sits between authentication and enforcement.
+- Show `{{SignalGridBaseUrl}}/demo` flow.
+- Reference `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all` to demonstrate scenario coverage.
+- Use `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg` to explain where SignalGrid sits between authentication and enforcement.
 
 Prompt reactions:
 - “What feels realistic vs. hand-wavy?”
@@ -156,11 +157,11 @@ Evaluate whether SignalGrid improves clarity and speed of access outcomes in a l
 ## 7) Short Demo Walkthrough Script
 “Thanks for taking a look — I’ll keep this brief and concrete.
 
-First, I’ll open `/demo` and walk through the current runtime decision flow end-to-end for shared-device and mobile frontline scenarios. As we do this, note where your endpoint, mobility/UEM, IAM, and frontline IT ownership boundaries show up.
+First, I’ll open `{{SignalGridBaseUrl}}/demo` and walk through the current runtime decision flow end-to-end for shared-device and mobile frontline scenarios. As we do this, note where your endpoint, mobility/UEM, IAM, and frontline IT ownership boundaries show up.
 
-Second, I’ll reference `/api/demo/verify?scenario=all` to show that each demo scenario path is wired and verifiable in the current build.
+Second, I’ll reference `{{SignalGridBaseUrl}}/api/demo/verify?scenario=all` to show that each demo scenario path is wired and verifiable in the current build.
 
-Third, I’ll pull up `docs/assets/signalgrid-runtime-architecture.svg` to anchor where SignalGrid fits between authentication and enforcement.
+Third, I’ll pull up `{{SignalGridBaseUrl}}/assets/signalgrid-runtime-architecture.svg` to anchor where SignalGrid fits between authentication and enforcement.
 
 Important context: this is design-partner stage. We’re not positioning this as production-ready, and remediation actions are represented as simulated talk-track unless validated in your environment.
 

--- a/docs/LAUNCH_OUTREACH_PACKAGE.md
+++ b/docs/LAUNCH_OUTREACH_PACKAGE.md
@@ -1,0 +1,174 @@
+# SignalGrid Launch Outreach Package
+
+## Purpose
+This package is for early design-partner outreach using the current landing page, demo, and architecture visual. It is designed to start high-quality conversations and secure pilot discovery calls.
+
+## Guardrails
+- Do **not** position SignalGrid as production-ready.
+- Do **not** imply compliance certification or legal guarantees.
+- Do **not** claim replacement of existing IAM, UEM, endpoint security, or broader enterprise security programs.
+- Keep remediation language explicitly simulated/talk-track unless validated in a production setting.
+
+---
+
+## 1) LinkedIn Teaser Post
+I’m opening a small design-partner feedback loop for SignalGrid.
+SignalGrid is a runtime decision layer for shared-device and mobile frontline environments.
+The goal is simple:
+help teams make clearer access decisions using identity, device posture, and session context before workflows break.
+What I can show today:
+- a live `/demo` flow
+- scenario verification through `/api/demo/verify?scenario=all`
+- an architecture view showing where SignalGrid fits between authentication and enforcement
+This is early and intentionally scoped. Not a production rollout pitch.
+If you work in endpoint, mobility, IAM, UEM, frontline IT, or security architecture and this problem sounds familiar, I’d value 15 minutes of candid feedback.
+
+---
+
+## 2) Founder Intro (short form)
+Hi — I’m building SignalGrid as a runtime decision layer for shared-device and mobile frontline environments.
+
+The focus is helping teams make better access outcomes before workflows break by combining identity signals, device posture, and session context.
+
+Right now, SignalGrid is in design-partner mode: we can walk through the current demo and architecture, then co-define what practical value should look like in your frontline workflows.
+
+If relevant, I can share a concise pilot outline and set up a 15-minute discovery call.
+
+---
+
+## 3) Design-Partner Outreach Email
+**Subject options**
+- Exploring a SignalGrid design-partner pilot for frontline access decisions
+- Quick intro: SignalGrid for shared-device and mobile frontline workflows
+- 15 min? Runtime decision workflow feedback (IAM/UEM/frontline IT)
+
+Hi {{FirstName}},
+
+I’m reaching out because your team’s work in {{Company/Area}} seems closely aligned with a problem I’m building around: making access decisions faster and clearer in shared-device and mobile frontline environments.
+
+I’m currently running a small design-partner motion for **SignalGrid**. This is not a production rollout pitch — it’s a structured feedback loop with endpoint, mobility, IAM, UEM, frontline IT, and security architecture leaders.
+
+What we can share today:
+- live product flow at `/demo`
+- verification endpoint: `/api/demo/verify?scenario=all`
+- architecture explainer: `docs/assets/signalgrid-runtime-architecture.svg`
+
+If useful, I’d love a 15-minute discovery call to understand your current access-decision workflow and see if a short pilot is worth scoping.
+
+Best,
+{{Your Name}}
+{{Role}}
+{{Contact}}
+
+---
+
+## 4) Follow-up Email
+**Subject:** Re: SignalGrid design-partner intro
+
+Hi {{FirstName}},
+
+Following up in case this got buried.
+
+If shared-device or mobile frontline access workflows are on your roadmap this quarter, I can share:
+- a 5-minute demo walkthrough,
+- the architecture visual,
+- and a one-page pilot outline for feedback.
+
+No hard pitch — just trying to validate where this is genuinely useful for operational continuity and access outcomes.
+
+Open to a short 15-minute call next week?
+
+Best,
+{{Your Name}}
+
+---
+
+## 5) 15-Minute Discovery Call Script
+## 0:00–2:00 — Context
+- Thank them for time.
+- Set expectations: “This is an early design-partner conversation, not a production deployment discussion.”
+- Confirm role and ownership areas (endpoint engineering, mobility/UEM, IAM/identity architecture, frontline IT operations, security architecture).
+
+## 2:00–6:00 — Current State
+Ask:
+1. How are access decisions currently made for shared-device and mobile frontline workflows?
+2. Where do decisions stall when identity, device posture, and session context conflict?
+3. Which access outcomes are repetitive but still manual?
+4. What would make a pilot worthwhile in 30–45 days?
+
+## 6:00–10:00 — Show + React
+- Show `/demo` flow.
+- Reference `/api/demo/verify?scenario=all` to demonstrate scenario coverage.
+- Use `docs/assets/signalgrid-runtime-architecture.svg` to explain where SignalGrid sits between authentication and enforcement.
+
+Prompt reactions:
+- “What feels realistic vs. hand-wavy?”
+- “What’s missing to make this usable by your team?”
+- “What would block adoption internally?”
+
+## 10:00–13:00 — Pilot Fit
+- Confirm whether this is a fit for design-partner pilot exploration.
+- Clarify boundaries: remediation remains simulated/talk-track unless jointly validated.
+- Define one success signal (e.g., faster access-decision resolution in a constrained frontline workflow).
+
+## 13:00–15:00 — Next Step
+- If fit: schedule pilot scoping session.
+- If not fit: ask permission for future check-in and referral.
+
+---
+
+## 6) One-Page Pilot Offer Outline
+## Pilot Title
+SignalGrid Design-Partner Pilot (Evaluation)
+
+## Objective
+Evaluate whether SignalGrid improves clarity and speed of access outcomes in a limited, non-production decision-support workflow for shared-device and mobile frontline environments.
+
+## Scope (Initial)
+- 1–2 representative shared-device/mobile frontline access scenarios
+- limited participant group (endpoint/mobility + IAM + frontline IT + security architecture)
+- structured weekly feedback loop
+- target segments such as healthcare, logistics, retail, and other regulated frontline environments
+
+## What We Provide
+- guided demo and architecture walkthrough
+- baseline access-decision workflow mapping
+- simulated remediation talk-track (clearly marked non-production)
+- short iteration cycle based on operator feedback
+
+## What Partner Provides
+- current-state workflow context
+- stakeholder feedback access
+- designated point-of-contact for pilot cadence
+
+## Success Criteria (example)
+- reduced decision ambiguity in target access scenarios
+- faster access resolution without unnecessary workflow interruption
+- clear go/no-go criteria for expanded evaluation
+
+## Explicit Non-Claims
+- no guarantee of compliance outcomes
+- no claim of replacing existing IAM/UEM/endpoint/security tooling
+- no claim of production-ready autonomous remediation
+
+---
+
+## 7) Short Demo Walkthrough Script
+“Thanks for taking a look — I’ll keep this brief and concrete.
+
+First, I’ll open `/demo` and walk through the current runtime decision flow end-to-end for shared-device and mobile frontline scenarios. As we do this, note where your endpoint, mobility/UEM, IAM, and frontline IT ownership boundaries show up.
+
+Second, I’ll reference `/api/demo/verify?scenario=all` to show that each demo scenario path is wired and verifiable in the current build.
+
+Third, I’ll pull up `docs/assets/signalgrid-runtime-architecture.svg` to anchor where SignalGrid fits between authentication and enforcement.
+
+Important context: this is design-partner stage. We’re not positioning this as production-ready, and remediation actions are represented as simulated talk-track unless validated in your environment.
+
+After the walkthrough, I want your direct feedback on three things: what’s credible, what’s missing, and what would make this worth piloting.”
+
+---
+
+## Suggested CTA Options
+- “Open to a 15-minute discovery call next week?”
+- “Want the 1-page pilot outline and 5-minute walkthrough?”
+- “If this isn’t your lane, who on your team owns frontline shared-device/mobile access decisions?”


### PR DESCRIPTION
### Motivation
- Provide a ready-to-use outreach package to recruit design partners and standardize messaging for early SignalGrid conversations. 
- Ensure consistent guardrails so outreach does not position SignalGrid as production-ready or imply compliance guarantees. 
- Centralize templates and scripts to speed discovery calls, demos, and pilot scoping. 
- Make it easy to reference demo endpoints and architecture assets during outreach. 

### Description
- Add `docs/LAUNCH_OUTREACH_PACKAGE.md` containing a LinkedIn teaser, short founder intro, outreach and follow-up email templates, a 15-minute discovery call script, a one-page pilot offer outline, a demo walkthrough script, and suggested CTAs. 
- Embed explicit guardrails and non-claims to keep pilot discussions scoped and remediation language clearly simulated. 
- Reference live/demo endpoints and assets such as `/demo`, `/api/demo/verify?scenario=all`, and `docs/assets/signalgrid-runtime-architecture.svg` for reproducible demos. 
- This is a documentation-only change and does not modify runtime code. 

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cdfbf8318832e801460d339bc6d86)