### PR TITLE
Retire: mark as legacy POC/concept — superseded by SignalGrid-Review-Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> # ⚠️ Legacy — retired POC / concept
+>
+> **This repository is a retired proof-of-concept (pre-dev / concept stage).**
+> Active development has moved to the consolidated, canonical monorepo:
+>
+> → **[DanFashauer/SignalGrid-Review-Hub](https://github.com/DanFashauer/SignalGrid-Review-Hub)** (dev → alpha → beta → prod tiers; live demo, deterministic core, control plane, docs).
+>
+> This repo is kept for history only and is no longer maintained. Please use the canonical repo above.
+
+---
+
 # SignalGrid
 
 <p align="left">


### PR DESCRIPTION
## Summary

Marks this repository as a **retired POC / concept** (pre-dev stage). Active development has moved to the consolidated, canonical monorepo **[DanFashauer/SignalGrid-Review-Hub](https://github.com/DanFashauer/SignalGrid-Review-Hub)** (dev → alpha → beta → prod tiers).

## What changed

- **`README.md`** — prepends a clear "⚠️ Legacy — retired POC / concept" banner redirecting anyone who lands here to the canonical repo. No code touched.

## Next step (owner)

- Merge this, then **archive the repository** (Settings → General → Archive this repository) so it's read-only with the "Public archive" banner — the standard "legacy" signal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3GJ2Fs8sVppPgzuJdnNLn)_